### PR TITLE
feat(store): Store Protocol contract + InMemoryStore

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -10,7 +10,44 @@ _To be written during v0.2.0._
 
 ## Two-phase TTL for the `in_flight` state
 
-_To be written during v0.1.0._
+**Status: v0.1.0.**
+
+A record has two lifetime phases with separate TTLs:
+
+- `in_flight_ttl` (default 30s): time the handler has to finish. A crashed or
+  killed process can't run cleanup, so we rely on the short TTL to reclaim the
+  slot — no separate crash-recovery mechanism in the store.
+- `completed_ttl` (default 24h): time the cached response replays for once the
+  handler succeeds. This is the window the client has to safely retry.
+
+`Store.complete` replaces the IN_FLIGHT record with a COMPLETED one, resetting
+`expires_at` to `now + completed_ttl`. `Store.release` removes the slot
+outright — it's the explicit-cleanup path used when the handler raised or
+returned a status we don't cache.
+
+### Time source
+
+All TTL math uses `time.time()` (wall-clock seconds since epoch). Alternatives
+considered:
+
+- `time.monotonic()`: safer against clock jumps within a process, but can't be
+  compared across processes. The Redis backend (v0.2.0) will use wall-clock
+  `EXPIRE` semantics, and having the in-memory store agree on units keeps
+  cross-backend tests meaningful.
+- Per-record `datetime`: heavier, no benefit at this scale.
+
+The trade-off accepted: a wall-clock jump backwards could keep an expired slot
+alive for longer than intended. In practice, servers are NTP-synced and the
+window is milliseconds. Documented rather than engineered around.
+
+### `release` is idempotent
+
+Calling `release` on a key that doesn't exist (already expired, or never
+acquired) is a no-op, not an error. Reason: the middleware's cleanup path on
+a 5xx response races with `in_flight_ttl` expiry — if the TTL wins, the slot
+is gone by the time `release` runs, and raising would crash the error-handling
+path. Keeping `release` idempotent means the middleware doesn't need to guard
+every call with `try/except`.
 
 ## Body fingerprint scope
 

--- a/src/fastapi_idempotency/store.py
+++ b/src/fastapi_idempotency/store.py
@@ -17,9 +17,17 @@ class Store(Protocol):
     """Pluggable storage backend for idempotency records.
 
     Implementations must be safe under concurrent access. ``acquire`` is
-    the only method that must be atomic: it performs the compare-and-set
-    that decides which of the four :class:`AcquireOutcome` branches the
-    caller takes. The remaining methods may be straightforward reads/writes.
+    the only method that must be atomic: it is the single compare-and-set
+    that classifies the request into one of the four
+    :class:`AcquireOutcome` branches. ``get``, ``complete``, and
+    ``release`` may be straightforward reads/writes, but implementations
+    are still responsible for any locking their data structure needs
+    (e.g. an in-memory dict requires an ``asyncio.Lock``).
+
+    Expiry is time-based: every record carries ``expires_at`` and stores
+    treat records whose ``expires_at`` has elapsed as absent. Stores use
+    their own clock (``time.time`` in the in-memory backend, ``EXPIRE``
+    in Redis); no real-time precision is promised.
     """
 
     async def acquire(
@@ -30,16 +38,34 @@ class Store(Protocol):
     ) -> AcquireResult:
         """Atomically claim or inspect an idempotency slot.
 
-        The returned :class:`AcquireResult` tells the caller what to do
-        next: implement the request (``CREATED``), respond 409
-        (``IN_FLIGHT``), replay the stored response (``REPLAY``), or
-        respond 422 (``MISMATCH``). Fingerprint comparison is the store's
-        responsibility to avoid a TOCTOU race between read and compare.
+        Classification rules (all checked inside the atomic section):
+
+        - No record, or the existing record has expired → insert a fresh
+          IN_FLIGHT record and return ``CREATED``. The caller now owns
+          the slot and must eventually call ``complete`` or ``release``.
+        - Existing, unexpired record with a different fingerprint →
+          ``MISMATCH``. The caller should respond 422; the stored
+          response (if any) is returned for diagnostic purposes but not
+          meant to be replayed.
+        - Existing, unexpired record with the same fingerprint and state
+          ``IN_FLIGHT`` → ``IN_FLIGHT``. The caller should respond 409.
+        - Existing, unexpired record with the same fingerprint and state
+          ``COMPLETED`` → ``REPLAY``. The caller replays
+          ``record.response`` verbatim (the ``Idempotent-Replayed``
+          header is added by the middleware, not the store).
+
+        Fingerprint comparison happens inside the atomic section so no
+        TOCTOU race can classify the request twice differently.
         """
         ...
 
     async def get(self, key: IdempotencyKey) -> IdempotencyRecord | None:
-        """Fetch a record by key, or return ``None`` if absent or expired."""
+        """Fetch a record by key, or return ``None`` if absent or expired.
+
+        A non-mutating read: expired records are not deleted as a side
+        effect of ``get``. Cleanup happens lazily inside ``acquire`` when
+        the slot is reclaimed.
+        """
         ...
 
     async def complete(
@@ -48,14 +74,31 @@ class Store(Protocol):
         response: CachedResponse,
         ttl: float,
     ) -> None:
-        """Transition IN_FLIGHT → COMPLETED and persist the response for ``ttl`` seconds."""
+        """Transition IN_FLIGHT → COMPLETED, persisting ``response`` for ``ttl`` seconds.
+
+        Preserves ``key``, ``fingerprint``, and ``created_at`` from the
+        in-flight record; overwrites ``state``, ``expires_at``, and
+        ``response``.
+
+        The caller must own the slot (i.e. previously received
+        ``CREATED`` from ``acquire``). If no record exists for ``key``
+        — typically because the in-flight TTL elapsed before the handler
+        finished — the store raises :class:`StoreError`. Tune
+        ``in_flight_ttl`` upward if this fires in production.
+        """
         ...
 
     async def release(self, key: IdempotencyKey) -> None:
-        """Remove an IN_FLIGHT slot after the handler raised before completing.
+        """Remove the slot for ``key``; no-op if no record exists.
 
-        This is the explicit-cleanup path. Process crashes are handled
-        passively by ``in_flight_ttl`` expiring the orphaned slot — stores
-        do not need a separate recovery mechanism.
+        This is the explicit-cleanup path used when the handler raised
+        or returned an uncached status (5xx, redirects, etc.). Idempotent
+        by design so the middleware's error path can call it
+        unconditionally — it races with ``in_flight_ttl`` expiry, and
+        raising on a missing record would crash the error handler.
+
+        Process crashes are handled passively by ``in_flight_ttl``
+        expiring the orphaned slot; stores do not need a separate
+        recovery mechanism.
         """
         ...

--- a/src/fastapi_idempotency/stores/memory.py
+++ b/src/fastapi_idempotency/stores/memory.py
@@ -38,20 +38,35 @@ class InMemoryStore:
     ) -> AcquireResult:
         async with self._lock:
             now = time.time()
-            record = IdempotencyRecord(
-                key=key,
-                fingerprint=fingerprint,
-                state=IdempotencyState.IN_FLIGHT,
-                created_at=now,
-                expires_at=now + ttl,
-                response=None,
-            )
-            self._records[key] = record
-            return AcquireResult(outcome=AcquireOutcome.CREATED, record=record)
+            existing = self._records.get(key)
+            if existing is not None and existing.is_expired(now):
+                existing = None
+
+            if existing is None:
+                record = IdempotencyRecord(
+                    key=key,
+                    fingerprint=fingerprint,
+                    state=IdempotencyState.IN_FLIGHT,
+                    created_at=now,
+                    expires_at=now + ttl,
+                    response=None,
+                )
+                self._records[key] = record
+                return AcquireResult(outcome=AcquireOutcome.CREATED, record=record)
+
+            if existing.fingerprint != fingerprint:
+                return AcquireResult(outcome=AcquireOutcome.MISMATCH, record=existing)
+
+            if existing.state is IdempotencyState.IN_FLIGHT:
+                return AcquireResult(outcome=AcquireOutcome.IN_FLIGHT, record=existing)
+            return AcquireResult(outcome=AcquireOutcome.REPLAY, record=existing)
 
     async def get(self, key: IdempotencyKey) -> IdempotencyRecord | None:
         async with self._lock:
-            return self._records.get(key)
+            record = self._records.get(key)
+            if record is None or record.is_expired(time.time()):
+                return None
+            return record
 
     async def complete(
         self,

--- a/src/fastapi_idempotency/stores/memory.py
+++ b/src/fastapi_idempotency/stores/memory.py
@@ -50,7 +50,8 @@ class InMemoryStore:
             return AcquireResult(outcome=AcquireOutcome.CREATED, record=record)
 
     async def get(self, key: IdempotencyKey) -> IdempotencyRecord | None:
-        raise NotImplementedError
+        async with self._lock:
+            return self._records.get(key)
 
     async def complete(
         self,
@@ -61,4 +62,5 @@ class InMemoryStore:
         raise NotImplementedError
 
     async def release(self, key: IdempotencyKey) -> None:
-        raise NotImplementedError
+        async with self._lock:
+            self._records.pop(key, None)

--- a/src/fastapi_idempotency/stores/memory.py
+++ b/src/fastapi_idempotency/stores/memory.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
+
 from fastapi_idempotency.types import (
+    AcquireOutcome,
     AcquireResult,
     CachedResponse,
     Fingerprint,
     IdempotencyKey,
     IdempotencyRecord,
+    IdempotencyState,
 )
 
 
@@ -21,13 +26,28 @@ class InMemoryStore:
     Structurally conforms to :class:`fastapi_idempotency.store.Store`.
     """
 
+    def __init__(self) -> None:
+        self._records: dict[IdempotencyKey, IdempotencyRecord] = {}
+        self._lock = asyncio.Lock()
+
     async def acquire(
         self,
         key: IdempotencyKey,
         fingerprint: Fingerprint,
         ttl: float,
     ) -> AcquireResult:
-        raise NotImplementedError
+        async with self._lock:
+            now = time.time()
+            record = IdempotencyRecord(
+                key=key,
+                fingerprint=fingerprint,
+                state=IdempotencyState.IN_FLIGHT,
+                created_at=now,
+                expires_at=now + ttl,
+                response=None,
+            )
+            self._records[key] = record
+            return AcquireResult(outcome=AcquireOutcome.CREATED, record=record)
 
     async def get(self, key: IdempotencyKey) -> IdempotencyRecord | None:
         raise NotImplementedError

--- a/src/fastapi_idempotency/stores/memory.py
+++ b/src/fastapi_idempotency/stores/memory.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import time
+from dataclasses import replace
 
+from fastapi_idempotency.errors import StoreError
 from fastapi_idempotency.types import (
     AcquireOutcome,
     AcquireResult,
@@ -74,7 +76,18 @@ class InMemoryStore:
         response: CachedResponse,
         ttl: float,
     ) -> None:
-        raise NotImplementedError
+        async with self._lock:
+            existing = self._records.get(key)
+            if existing is None:
+                raise StoreError(
+                    f"cannot complete unknown idempotency key: {key!r}",
+                )
+            self._records[key] = replace(
+                existing,
+                state=IdempotencyState.COMPLETED,
+                expires_at=time.time() + ttl,
+                response=response,
+            )
 
     async def release(self, key: IdempotencyKey) -> None:
         async with self._lock:

--- a/src/fastapi_idempotency/types.py
+++ b/src/fastapi_idempotency/types.py
@@ -52,6 +52,15 @@ class IdempotencyRecord:
     expires_at: float
     response: CachedResponse | None = None
 
+    def is_expired(self, now: float) -> bool:
+        """Whether ``expires_at`` has elapsed as of ``now``.
+
+        The clock is injected so the domain stays free of
+        ``time.time`` / ``time.monotonic`` calls; stores pass whichever
+        source they use for TTL math.
+        """
+        return self.expires_at <= now
+
 
 @dataclass(frozen=True, slots=True)
 class AcquireResult:

--- a/tests/test_stores_memory.py
+++ b/tests/test_stores_memory.py
@@ -12,17 +12,48 @@ from fastapi_idempotency import (
     InMemoryStore,
 )
 
+KEY = IdempotencyKey("order-123")
+FP = Fingerprint("abc")
+
 
 async def test_acquire_returns_created_on_first_call() -> None:
     store = InMemoryStore()
-    key = IdempotencyKey("order-123")
-    fingerprint = Fingerprint("abc")
 
-    result = await store.acquire(key, fingerprint, ttl=30.0)
+    result = await store.acquire(KEY, FP, ttl=30.0)
 
     assert result.outcome is AcquireOutcome.CREATED
-    assert result.record.key == key
-    assert result.record.fingerprint == fingerprint
+    assert result.record.key == KEY
+    assert result.record.fingerprint == FP
     assert result.record.state is IdempotencyState.IN_FLIGHT
     assert result.record.response is None
     assert result.record.expires_at > time.time()
+
+
+async def test_get_returns_none_for_unknown_key() -> None:
+    store = InMemoryStore()
+
+    assert await store.get(KEY) is None
+
+
+async def test_get_returns_the_record_for_a_known_key() -> None:
+    store = InMemoryStore()
+    acquired = await store.acquire(KEY, FP, ttl=30.0)
+
+    fetched = await store.get(KEY)
+
+    assert fetched == acquired.record
+
+
+async def test_release_removes_an_in_flight_slot() -> None:
+    store = InMemoryStore()
+    await store.acquire(KEY, FP, ttl=30.0)
+
+    await store.release(KEY)
+
+    assert await store.get(KEY) is None
+
+
+async def test_release_on_a_missing_key_is_a_noop() -> None:
+    store = InMemoryStore()
+
+    await store.release(KEY)  # must not raise

--- a/tests/test_stores_memory.py
+++ b/tests/test_stores_memory.py
@@ -4,16 +4,25 @@ from __future__ import annotations
 
 import time
 
+import pytest
+
 from fastapi_idempotency import (
     AcquireOutcome,
+    CachedResponse,
     Fingerprint,
     IdempotencyKey,
     IdempotencyState,
     InMemoryStore,
+    StoreError,
 )
 
 KEY = IdempotencyKey("order-123")
 FP = Fingerprint("abc")
+RESPONSE = CachedResponse(
+    status_code=201,
+    headers=((b"content-type", b"application/json"),),
+    body=b'{"id": 1}',
+)
 
 
 async def test_acquire_returns_created_on_first_call() -> None:
@@ -93,3 +102,34 @@ async def test_get_returns_none_for_an_expired_record() -> None:
     await store.acquire(KEY, FP, ttl=-1.0)
 
     assert await store.get(KEY) is None
+
+
+async def test_complete_transitions_in_flight_to_completed_with_response() -> None:
+    store = InMemoryStore()
+    await store.acquire(KEY, FP, ttl=30.0)
+
+    await store.complete(KEY, RESPONSE, ttl=3600.0)
+
+    record = await store.get(KEY)
+    assert record is not None
+    assert record.state is IdempotencyState.COMPLETED
+    assert record.response == RESPONSE
+    assert record.fingerprint == FP  # preserved from the in-flight record
+
+
+async def test_acquire_after_complete_returns_replay() -> None:
+    store = InMemoryStore()
+    await store.acquire(KEY, FP, ttl=30.0)
+    await store.complete(KEY, RESPONSE, ttl=3600.0)
+
+    result = await store.acquire(KEY, FP, ttl=30.0)
+
+    assert result.outcome is AcquireOutcome.REPLAY
+    assert result.record.response == RESPONSE
+
+
+async def test_complete_raises_store_error_on_unknown_key() -> None:
+    store = InMemoryStore()
+
+    with pytest.raises(StoreError):
+        await store.complete(KEY, RESPONSE, ttl=3600.0)

--- a/tests/test_stores_memory.py
+++ b/tests/test_stores_memory.py
@@ -1,0 +1,28 @@
+"""Acceptance tests for InMemoryStore."""
+
+from __future__ import annotations
+
+import time
+
+from fastapi_idempotency import (
+    AcquireOutcome,
+    Fingerprint,
+    IdempotencyKey,
+    IdempotencyState,
+    InMemoryStore,
+)
+
+
+async def test_acquire_returns_created_on_first_call() -> None:
+    store = InMemoryStore()
+    key = IdempotencyKey("order-123")
+    fingerprint = Fingerprint("abc")
+
+    result = await store.acquire(key, fingerprint, ttl=30.0)
+
+    assert result.outcome is AcquireOutcome.CREATED
+    assert result.record.key == key
+    assert result.record.fingerprint == fingerprint
+    assert result.record.state is IdempotencyState.IN_FLIGHT
+    assert result.record.response is None
+    assert result.record.expires_at > time.time()

--- a/tests/test_stores_memory.py
+++ b/tests/test_stores_memory.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
+from collections import Counter
 
 import pytest
 
@@ -133,3 +135,15 @@ async def test_complete_raises_store_error_on_unknown_key() -> None:
 
     with pytest.raises(StoreError):
         await store.complete(KEY, RESPONSE, ttl=3600.0)
+
+
+async def test_concurrent_acquire_yields_exactly_one_created() -> None:
+    store = InMemoryStore()
+
+    results = await asyncio.gather(
+        *(store.acquire(KEY, FP, ttl=30.0) for _ in range(10)),
+    )
+
+    outcomes = Counter(r.outcome for r in results)
+    assert outcomes[AcquireOutcome.CREATED] == 1
+    assert outcomes[AcquireOutcome.IN_FLIGHT] == 9

--- a/tests/test_stores_memory.py
+++ b/tests/test_stores_memory.py
@@ -57,3 +57,39 @@ async def test_release_on_a_missing_key_is_a_noop() -> None:
     store = InMemoryStore()
 
     await store.release(KEY)  # must not raise
+
+
+async def test_acquire_with_same_key_and_fingerprint_returns_in_flight() -> None:
+    store = InMemoryStore()
+    await store.acquire(KEY, FP, ttl=30.0)
+
+    result = await store.acquire(KEY, FP, ttl=30.0)
+
+    assert result.outcome is AcquireOutcome.IN_FLIGHT
+    assert result.record.state is IdempotencyState.IN_FLIGHT
+
+
+async def test_acquire_with_different_fingerprint_returns_mismatch() -> None:
+    store = InMemoryStore()
+    await store.acquire(KEY, FP, ttl=30.0)
+
+    result = await store.acquire(KEY, Fingerprint("other"), ttl=30.0)
+
+    assert result.outcome is AcquireOutcome.MISMATCH
+    assert result.record.fingerprint == FP
+
+
+async def test_acquire_on_an_expired_record_creates_a_fresh_slot() -> None:
+    store = InMemoryStore()
+    await store.acquire(KEY, FP, ttl=-1.0)  # already expired
+
+    result = await store.acquire(KEY, FP, ttl=30.0)
+
+    assert result.outcome is AcquireOutcome.CREATED
+
+
+async def test_get_returns_none_for_an_expired_record() -> None:
+    store = InMemoryStore()
+    await store.acquire(KEY, FP, ttl=-1.0)
+
+    assert await store.get(KEY) is None


### PR DESCRIPTION
Closes #1.

## What's in

- `Store` Protocol finalized: four-way `AcquireOutcome` classification happens atomically inside `acquire`; docstrings spell out each branch.
- `InMemoryStore` backed by `dict` + `asyncio.Lock`, conforming structurally to the Protocol.
- Domain method `IdempotencyRecord.is_expired(now)` — stores inject the clock, domain stays free of `time.*` calls.
- 13 acceptance tests covering all four `AcquireOutcome` branches, TTL expiry path, idempotent `release`, `StoreError` on orphaned `complete`, and concurrent `acquire` (10 coros → exactly one CREATED).
- 100% line + branch coverage on `stores/memory.py`.

## Design decisions locked in `docs/DESIGN.md`

- Time source: `time.time()` for cross-backend consistency with Redis' wall-clock `EXPIRE` (v0.2.0).
- `release` is idempotent on missing keys so the middleware's 5xx cleanup path can't crash on a TTL race.

## Deferred to issue #3 (middleware)

- **`complete` raises `StoreError` on a missing record.** The middleware will decide whether to catch it or let it propagate — belongs in that issue's decisions-to-make. For now: tune `in_flight_ttl` upward if this fires.
- **`asyncio.Lock` is defensive.** In single-thread asyncio with no `await` inside the critical section, the Lock is technically redundant right now. Kept because (a) it documents intent, (b) it future-proofs against an `await` being added later (serialization, hooks), (c) it matches the concurrency contract the Protocol promises.

## Verification

- `pytest tests/test_stores_memory.py` — 13 passed
- `mypy --strict src tests` — clean
- `ruff check src tests` — clean