### PR TITLE
refactor(types): move ScopeFactory out of the domain layer

### DIFF
--- a/src/fastapi_idempotency/__init__.py
+++ b/src/fastapi_idempotency/__init__.py
@@ -9,7 +9,7 @@ from .errors import (
     RequestTooLargeError,
     StoreError,
 )
-from .middleware import IdempotencyMiddleware
+from .middleware import IdempotencyMiddleware, ScopeFactory
 from .store import Store
 from .stores.memory import InMemoryStore
 from .types import (
@@ -20,7 +20,6 @@ from .types import (
     IdempotencyKey,
     IdempotencyRecord,
     IdempotencyState,
-    ScopeFactory,
 )
 
 __version__ = "0.1.0.dev0"

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -2,13 +2,23 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, TypeAlias
+
+from starlette.requests import Request
 
 if TYPE_CHECKING:
     from starlette.types import ASGIApp, Receive, Scope, Send
 
     from .store import Store
-    from .types import ScopeFactory
+
+
+ScopeFactory: TypeAlias = Callable[[Request], str | Awaitable[str]]
+"""Function that derives a scope string (e.g. tenant, user) from the request.
+
+Called by the middleware before key lookup; the result is prefixed onto
+the idempotency key so different scopes don't collide.
+"""
 
 
 class IdempotencyMiddleware:

--- a/src/fastapi_idempotency/types.py
+++ b/src/fastapi_idempotency/types.py
@@ -2,16 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import NewType, TypeAlias
-
-from starlette.requests import Request
+from typing import NewType
 
 IdempotencyKey = NewType("IdempotencyKey", str)
 Fingerprint = NewType("Fingerprint", str)
-ScopeFactory: TypeAlias = Callable[[Request], str | Awaitable[str]]
 
 
 class IdempotencyState(str, Enum):


### PR DESCRIPTION
## Why

Found during the post-#6 code review: \`types.py\` was importing
\`starlette.requests.Request\` purely to type \`ScopeFactory\`. That made the
domain layer transitively framework-aware, which contradicts the rest of the
package design (Protocol-based store contract, framework-free errors, etc.).

\`ScopeFactory\` is conceptually middleware territory — the middleware is what
extracts the Request and invokes the factory. Moving it there removes the
starlette import from the domain entirely.

## What changes

- \`ScopeFactory\` definition moves: \`types.py\` → \`middleware.py\`.
- \`types.py\` drops imports: \`starlette.requests.Request\`, \`Awaitable\`,
  \`Callable\`, \`TypeAlias\` (all were only used for ScopeFactory).
- \`__init__.py\` re-exports \`ScopeFactory\` from \`.middleware\` instead of
  \`.types\`. Public API is unchanged: \`from fastapi_idempotency import
  ScopeFactory\` still works.

## Why this isn't a breaking change

- Public import path unchanged.
- No code in the repo (or in any released version) imported it directly from
  \`fastapi_idempotency.types\` — only from the package root.

## Verification

- \`pytest\` — 23 passed
- \`mypy --strict src tests\` — clean
- \`ruff check src tests\` — clean

## Unblocks

- #3 (middleware core) will use \`ScopeFactory\` from a clean module.