### PR TITLE
feat(middleware): core middleware with two-phase TTL, replay, and error handling

### DIFF
--- a/src/fastapi_idempotency/fingerprint.py
+++ b/src/fastapi_idempotency/fingerprint.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+
 from .types import Fingerprint
 
 
@@ -13,13 +15,21 @@ def compute_fingerprint(
 ) -> Fingerprint:
     """Compute a stable fingerprint over ``method + path + query + body``.
 
-    Returns a hex-encoded SHA-256 digest. Two requests that share an
-    ``Idempotency-Key`` but disagree on any of these components are a
-    mismatch and the middleware will respond with ``422``. Query string
-    is included because it typically carries request semantics
-    (``?tenant=``, ``?dry_run=``, pagination, etc.).
+    Returns a hex-encoded SHA-256 digest. Each component is length-prefixed
+    before being fed to the hasher so prefix-aligned ambiguity is
+    impossible (e.g., ``method="POS", path="T/foo"`` cannot collide with
+    ``method="POST", path="/foo"``).
 
     Argument types follow the ASGI scope shape: ``path`` is ``str``,
     ``query_string`` is raw ``bytes``.
     """
-    raise NotImplementedError
+    h = hashlib.sha256()
+    for part in (
+        method.encode("ascii"),
+        path.encode("utf-8"),
+        query_string,
+        body,
+    ):
+        h.update(len(part).to_bytes(4, "big"))
+        h.update(part)
+    return Fingerprint(h.hexdigest())

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -42,6 +42,7 @@ class IdempotencyMiddleware:
         {"POST", "PATCH", "PUT", "DELETE"},
     )
     MAX_KEY_LENGTH: ClassVar[int] = 255
+    FIRST_SERVER_ERROR_STATUS: ClassVar[int] = 500
 
     def __init__(
         self,
@@ -148,10 +149,25 @@ class IdempotencyMiddleware:
         key: IdempotencyKey,
     ) -> None:
         capturer = _ResponseCapturer(send)
-        await self.app(scope, replay, capturer)
+        try:
+            await self.app(scope, replay, capturer)
+        except Exception:
+            # Handler raised before sending a response. Release the slot
+            # so a retry can run fresh, then propagate.
+            await self.store.release(key)
+            raise
+
+        if (
+            capturer.status is None
+            or capturer.status >= self.FIRST_SERVER_ERROR_STATUS
+        ):
+            # 5xx (or no response at all) is treated as a transient failure.
+            # Don't cache it — drop the slot so a retry runs the handler again.
+            await self.store.release(key)
+            return
 
         cached = CachedResponse(
-            status_code=capturer.status or 0,
+            status_code=capturer.status,
             headers=capturer.headers,
             body=bytes(capturer.body),
         )

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, ClassVar, TypeAlias
 
 from starlette.requests import Request
 
 from .body_buffer import buffer_request_body
+from .errors import StoreError
 from .fingerprint import compute_fingerprint
 from .types import (
     AcquireOutcome,
@@ -19,6 +21,9 @@ if TYPE_CHECKING:
     from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
     from .store import Store
+
+
+logger = logging.getLogger(__name__)
 
 
 ScopeFactory: TypeAlias = Callable[[Request], str | Awaitable[str]]
@@ -152,11 +157,11 @@ class IdempotencyMiddleware:
         send: Send,
         key: IdempotencyKey,
     ) -> None:
-        capturer = _ResponseCapturer(send)
+        capturer = _ResponseCapturer()
         try:
             await self.app(scope, replay, capturer)
         except Exception:
-            # Handler raised before sending a response. Release the slot
+            # Handler raised before producing a response. Release the slot
             # so a retry can run fresh, then propagate.
             await self.store.release(key)
             raise
@@ -168,6 +173,7 @@ class IdempotencyMiddleware:
             # 5xx (or no response at all) is treated as a transient failure.
             # Don't cache it — drop the slot so a retry runs the handler again.
             await self.store.release(key)
+            await self._emit_captured(send, capturer)
             return
 
         cached = CachedResponse(
@@ -175,7 +181,43 @@ class IdempotencyMiddleware:
             headers=capturer.headers,
             body=bytes(capturer.body),
         )
-        await self.store.complete(key, cached, ttl=self.completed_ttl)
+        extra_headers: tuple[tuple[bytes, bytes], ...] = ()
+        try:
+            await self.store.complete(key, cached, ttl=self.completed_ttl)
+        except StoreError:
+            # Per the deferred decision in issue #3: the request itself
+            # succeeded; surface the storage failure to the client via a
+            # header so retries know they won't replay.
+            logger.warning(
+                "store.complete raised StoreError for key=%r; serving "
+                "uncached response with Idempotency-Stored: false",
+                key,
+            )
+            extra_headers = ((b"idempotency-stored", b"false"),)
+
+        await self._emit_captured(send, capturer, extra_headers=extra_headers)
+
+    @staticmethod
+    async def _emit_captured(
+        send: Send,
+        capturer: _ResponseCapturer,
+        *,
+        extra_headers: tuple[tuple[bytes, bytes], ...] = (),
+    ) -> None:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": capturer.status or 0,
+                "headers": [*capturer.headers, *extra_headers],
+            },
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": bytes(capturer.body),
+                "more_body": False,
+            },
+        )
 
     @staticmethod
     async def _replay_response(send: Send, cached: CachedResponse) -> None:
@@ -247,11 +289,15 @@ class IdempotencyMiddleware:
 
 
 class _ResponseCapturer:
-    """Wraps an ASGI ``send`` to forward messages downstream while
-    accumulating status, headers, and body for later caching."""
+    """Buffers status, headers, and body emitted by the wrapped app.
 
-    def __init__(self, downstream: Send) -> None:
-        self._downstream = downstream
+    The middleware emits the captured response to its own ``send`` after
+    it has decided whether to ``complete`` or ``release`` the slot —
+    that lets it amend headers (e.g., ``Idempotency-Stored: false``)
+    based on the storage outcome.
+    """
+
+    def __init__(self) -> None:
         self.status: int | None = None
         self.headers: tuple[tuple[bytes, bytes], ...] = ()
         self.body = bytearray()
@@ -262,4 +308,3 @@ class _ResponseCapturer:
             self.headers = tuple(message.get("headers", []))
         elif message["type"] == "http.response.body":
             self.body.extend(message.get("body", b""))
-        await self._downstream(message)

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -7,8 +7,16 @@ from typing import TYPE_CHECKING, ClassVar, TypeAlias
 
 from starlette.requests import Request
 
+from .body_buffer import buffer_request_body
+from .fingerprint import compute_fingerprint
+from .types import (
+    AcquireOutcome,
+    CachedResponse,
+    IdempotencyKey,
+)
+
 if TYPE_CHECKING:
-    from starlette.types import ASGIApp, Receive, Scope, Send
+    from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
     from .store import Store
 
@@ -43,6 +51,7 @@ class IdempotencyMiddleware:
         header_name: str = "Idempotency-Key",
         in_flight_ttl: float = 30.0,
         completed_ttl: float = 86_400.0,
+        max_body_bytes: int | None = None,
         scope_factory: ScopeFactory | None = None,
     ) -> None:
         self.app = app
@@ -50,6 +59,7 @@ class IdempotencyMiddleware:
         self.header_name = header_name
         self.in_flight_ttl = in_flight_ttl
         self.completed_ttl = completed_ttl
+        self.max_body_bytes = max_body_bytes
         self.scope_factory = scope_factory
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
@@ -74,8 +84,44 @@ class IdempotencyMiddleware:
             )
             return
 
-        # TODO: full idempotency flow lands in subsequent slices.
+        key = IdempotencyKey(key_value)
+        body, replay = await buffer_request_body(
+            receive, max_bytes=self.max_body_bytes,
+        )
+        fingerprint = compute_fingerprint(
+            scope["method"],
+            scope["path"],
+            scope.get("query_string", b""),
+            body,
+        )
+
+        result = await self.store.acquire(
+            key, fingerprint, ttl=self.in_flight_ttl,
+        )
+
+        if result.outcome is AcquireOutcome.CREATED:
+            await self._run_and_cache(scope, replay, send, key)
+            return
+
+        # TODO(slice 5): handle IN_FLIGHT, REPLAY, MISMATCH.
         raise NotImplementedError
+
+    async def _run_and_cache(
+        self,
+        scope: Scope,
+        replay: Receive,
+        send: Send,
+        key: IdempotencyKey,
+    ) -> None:
+        capturer = _ResponseCapturer(send)
+        await self.app(scope, replay, capturer)
+
+        cached = CachedResponse(
+            status_code=capturer.status or 0,
+            headers=capturer.headers,
+            body=bytes(capturer.body),
+        )
+        await self.store.complete(key, cached, ttl=self.completed_ttl)
 
     def _extract_key(self, scope: Scope) -> str | None:
         target = self.header_name.lower().encode("latin-1")
@@ -110,3 +156,22 @@ class IdempotencyMiddleware:
         await send(
             {"type": "http.response.body", "body": body, "more_body": False},
         )
+
+
+class _ResponseCapturer:
+    """Wraps an ASGI ``send`` to forward messages downstream while
+    accumulating status, headers, and body for later caching."""
+
+    def __init__(self, downstream: Send) -> None:
+        self._downstream = downstream
+        self.status: int | None = None
+        self.headers: tuple[tuple[bytes, bytes], ...] = ()
+        self.body = bytearray()
+
+    async def __call__(self, message: Message) -> None:
+        if message["type"] == "http.response.start":
+            self.status = message["status"]
+            self.headers = tuple(message.get("headers", []))
+        elif message["type"] == "http.response.body":
+            self.body.extend(message.get("body", b""))
+        await self._downstream(message)

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -85,6 +85,10 @@ class IdempotencyMiddleware:
             )
             return
 
+        if self._content_length_exceeds_limit(scope):
+            await self.app(scope, receive, send)
+            return
+
         await self._handle_intercepted(
             scope, receive, send, IdempotencyKey(key_value),
         )
@@ -202,6 +206,22 @@ class IdempotencyMiddleware:
     def _is_valid_key(self, value: str) -> bool:
         # Per IETF draft: ASCII, 1..MAX_KEY_LENGTH chars.
         return 1 <= len(value) <= self.MAX_KEY_LENGTH and value.isascii()
+
+    def _content_length_exceeds_limit(self, scope: Scope) -> bool:
+        # Pre-check: if Content-Length declares a body bigger than the
+        # configured limit, skip idempotency entirely. We can't recover
+        # mid-buffer, so this header is the only fence we trust.
+        if self.max_body_bytes is None:
+            return False
+        headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
+        for name, value in headers:
+            if name.lower() == b"content-length":
+                try:
+                    declared = int(value)
+                except ValueError:
+                    return False
+                return declared > self.max_body_bytes
+        return False
 
     @staticmethod
     async def _send_plain_response(

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -95,7 +95,10 @@ class IdempotencyMiddleware:
             return
 
         await self._handle_intercepted(
-            scope, receive, send, IdempotencyKey(key_value),
+            scope,
+            receive,
+            send,
+            IdempotencyKey(key_value),
         )
 
     async def _handle_intercepted(
@@ -106,7 +109,8 @@ class IdempotencyMiddleware:
         key: IdempotencyKey,
     ) -> None:
         body, replay = await buffer_request_body(
-            receive, max_bytes=self.max_body_bytes,
+            receive,
+            max_bytes=self.max_body_bytes,
         )
         fingerprint = compute_fingerprint(
             scope["method"],
@@ -116,7 +120,9 @@ class IdempotencyMiddleware:
         )
 
         result = await self.store.acquire(
-            key, fingerprint, ttl=self.in_flight_ttl,
+            key,
+            fingerprint,
+            ttl=self.in_flight_ttl,
         )
 
         if result.outcome is AcquireOutcome.CREATED:
@@ -129,7 +135,9 @@ class IdempotencyMiddleware:
                 # Store contract says REPLAY → response is set; if we ever
                 # see this, it's a store bug. Treat as 500.
                 await self._send_plain_response(
-                    send, status=500, message="cached response missing",
+                    send,
+                    status=500,
+                    message="cached response missing",
                 )
                 return
             await self._replay_response(send, cached)
@@ -166,10 +174,7 @@ class IdempotencyMiddleware:
             await self.store.release(key)
             raise
 
-        if (
-            capturer.status is None
-            or capturer.status >= self.FIRST_SERVER_ERROR_STATUS
-        ):
+        if capturer.status is None or capturer.status >= self.FIRST_SERVER_ERROR_STATUS:
             # 5xx (or no response at all) is treated as a transient failure.
             # Don't cache it — drop the slot so a retry runs the handler again.
             await self.store.release(key)

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -84,7 +84,17 @@ class IdempotencyMiddleware:
             )
             return
 
-        key = IdempotencyKey(key_value)
+        await self._handle_intercepted(
+            scope, receive, send, IdempotencyKey(key_value),
+        )
+
+    async def _handle_intercepted(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+        key: IdempotencyKey,
+    ) -> None:
         body, replay = await buffer_request_body(
             receive, max_bytes=self.max_body_bytes,
         )
@@ -103,8 +113,32 @@ class IdempotencyMiddleware:
             await self._run_and_cache(scope, replay, send, key)
             return
 
-        # TODO(slice 5): handle IN_FLIGHT, REPLAY, MISMATCH.
-        raise NotImplementedError
+        if result.outcome is AcquireOutcome.REPLAY:
+            cached = result.record.response
+            if cached is None:
+                # Store contract says REPLAY → response is set; if we ever
+                # see this, it's a store bug. Treat as 500.
+                await self._send_plain_response(
+                    send, status=500, message="cached response missing",
+                )
+                return
+            await self._replay_response(send, cached)
+            return
+
+        if result.outcome is AcquireOutcome.IN_FLIGHT:
+            await self._send_plain_response(
+                send,
+                status=409,
+                message="request with this Idempotency-Key is in progress",
+            )
+            return
+
+        # MISMATCH
+        await self._send_plain_response(
+            send,
+            status=422,
+            message="Idempotency-Key reused with a different request body",
+        )
 
     async def _run_and_cache(
         self,
@@ -122,6 +156,24 @@ class IdempotencyMiddleware:
             body=bytes(capturer.body),
         )
         await self.store.complete(key, cached, ttl=self.completed_ttl)
+
+    @staticmethod
+    async def _replay_response(send: Send, cached: CachedResponse) -> None:
+        headers = [*cached.headers, (b"idempotent-replayed", b"true")]
+        await send(
+            {
+                "type": "http.response.start",
+                "status": cached.status_code,
+                "headers": headers,
+            },
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": cached.body,
+                "more_body": False,
+            },
+        )
 
     def _extract_key(self, scope: Scope) -> str | None:
         target = self.header_name.lower().encode("latin-1")

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, ClassVar, TypeAlias
 
 from starlette.requests import Request
 
@@ -30,6 +30,10 @@ class IdempotencyMiddleware:
     response pass-through (v0.2.0) remains possible.
     """
 
+    NON_SAFE_METHODS: ClassVar[frozenset[str]] = frozenset(
+        {"POST", "PATCH", "PUT", "DELETE"},
+    )
+
     def __init__(
         self,
         app: ASGIApp,
@@ -48,4 +52,25 @@ class IdempotencyMiddleware:
         self.scope_factory = scope_factory
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        if scope["method"] not in self.NON_SAFE_METHODS:
+            await self.app(scope, receive, send)
+            return
+
+        if self._extract_key(scope) is None:
+            await self.app(scope, receive, send)
+            return
+
+        # TODO: full idempotency flow lands in subsequent slices.
         raise NotImplementedError
+
+    def _extract_key(self, scope: Scope) -> str | None:
+        target = self.header_name.lower().encode("latin-1")
+        headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
+        for name, value in headers:
+            if name.lower() == target:
+                return value.decode("latin-1")
+        return None

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -33,6 +33,7 @@ class IdempotencyMiddleware:
     NON_SAFE_METHODS: ClassVar[frozenset[str]] = frozenset(
         {"POST", "PATCH", "PUT", "DELETE"},
     )
+    MAX_KEY_LENGTH: ClassVar[int] = 255
 
     def __init__(
         self,
@@ -60,8 +61,17 @@ class IdempotencyMiddleware:
             await self.app(scope, receive, send)
             return
 
-        if self._extract_key(scope) is None:
+        key_value = self._extract_key(scope)
+        if key_value is None:
             await self.app(scope, receive, send)
+            return
+
+        if not self._is_valid_key(key_value):
+            await self._send_plain_response(
+                send,
+                status=400,
+                message="invalid Idempotency-Key",
+            )
             return
 
         # TODO: full idempotency flow lands in subsequent slices.
@@ -74,3 +84,29 @@ class IdempotencyMiddleware:
             if name.lower() == target:
                 return value.decode("latin-1")
         return None
+
+    def _is_valid_key(self, value: str) -> bool:
+        # Per IETF draft: ASCII, 1..MAX_KEY_LENGTH chars.
+        return 1 <= len(value) <= self.MAX_KEY_LENGTH and value.isascii()
+
+    @staticmethod
+    async def _send_plain_response(
+        send: Send,
+        *,
+        status: int,
+        message: str,
+    ) -> None:
+        body = message.encode("utf-8")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": [
+                    (b"content-type", b"text/plain; charset=utf-8"),
+                    (b"content-length", str(len(body)).encode("ascii")),
+                ],
+            },
+        )
+        await send(
+            {"type": "http.response.body", "body": body, "more_body": False},
+        )

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -1,0 +1,61 @@
+"""Tests for compute_fingerprint."""
+
+from __future__ import annotations
+
+from fastapi_idempotency.fingerprint import compute_fingerprint
+
+
+def test_returns_64_char_hex_sha256() -> None:
+    fp = compute_fingerprint("POST", "/orders", b"", b"")
+
+    assert len(fp) == 64
+    assert all(c in "0123456789abcdef" for c in fp)
+
+
+def test_deterministic_for_same_inputs() -> None:
+    fp1 = compute_fingerprint("POST", "/orders", b"x=1", b'{"id":1}')
+    fp2 = compute_fingerprint("POST", "/orders", b"x=1", b'{"id":1}')
+
+    assert fp1 == fp2
+
+
+def test_method_change_changes_fingerprint() -> None:
+    a = compute_fingerprint("POST", "/orders", b"", b"")
+    b = compute_fingerprint("PUT", "/orders", b"", b"")
+
+    assert a != b
+
+
+def test_path_change_changes_fingerprint() -> None:
+    a = compute_fingerprint("POST", "/orders", b"", b"")
+    b = compute_fingerprint("POST", "/orders/1", b"", b"")
+
+    assert a != b
+
+
+def test_query_string_change_changes_fingerprint() -> None:
+    a = compute_fingerprint("POST", "/orders", b"x=1", b"")
+    b = compute_fingerprint("POST", "/orders", b"x=2", b"")
+
+    assert a != b
+
+
+def test_body_change_changes_fingerprint() -> None:
+    a = compute_fingerprint("POST", "/orders", b"", b'{"id":1}')
+    b = compute_fingerprint("POST", "/orders", b"", b'{"id":2}')
+
+    assert a != b
+
+
+def test_prefix_aligned_inputs_do_not_collide() -> None:
+    """method='POS' + path='T/foo' must not equal method='POST' + path='/foo'."""
+    a = compute_fingerprint("POST", "/foo", b"", b"")
+    b = compute_fingerprint("POS", "T/foo", b"", b"")
+
+    assert a != b
+
+
+def test_empty_body_works() -> None:
+    fp = compute_fingerprint("POST", "/orders", b"", b"")
+
+    assert len(fp) == 64

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -13,11 +13,15 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from fastapi_idempotency import (
+    CachedResponse,
+    Fingerprint,
     IdempotencyKey,
     IdempotencyMiddleware,
     IdempotencyState,
     InMemoryStore,
+    StoreError,
 )
+from fastapi_idempotency.types import AcquireResult, IdempotencyRecord
 
 if TYPE_CHECKING:
     from starlette.types import Message, Receive, Scope, Send
@@ -330,6 +334,57 @@ async def test_undersized_body_uses_idempotency() -> None:
         )
 
     assert await store.get(IdempotencyKey("x")) is not None
+
+
+async def test_store_error_on_complete_adds_idempotency_stored_false_header() -> None:
+    """If store.complete raises, the response is delivered with a header
+    flagging that retries won't replay."""
+
+    class FailingCompleteStore:
+        """Wraps an InMemoryStore but always raises on complete."""
+
+        def __init__(self) -> None:
+            self._inner = InMemoryStore()
+
+        async def acquire(
+            self,
+            key: IdempotencyKey,
+            fingerprint: Fingerprint,
+            ttl: float,
+        ) -> AcquireResult:
+            return await self._inner.acquire(key, fingerprint, ttl)
+
+        async def get(
+            self, key: IdempotencyKey,
+        ) -> IdempotencyRecord | None:
+            return await self._inner.get(key)
+
+        async def complete(
+            self,
+            key: IdempotencyKey,
+            response: CachedResponse,
+            ttl: float,
+        ) -> None:
+            del key, response, ttl
+            msg = "simulated eviction"
+            raise StoreError(msg)
+
+        async def release(self, key: IdempotencyKey) -> None:
+            await self._inner.release(key)
+
+    middleware = IdempotencyMiddleware(echo_app, FailingCompleteStore())
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/", headers={"Idempotency-Key": "x"}, content=b"hello",
+        )
+
+    assert response.status_code == 200
+    assert response.content == b"hello"
+    assert response.headers["idempotency-stored"] == "false"
 
 
 async def test_concurrent_request_with_same_key_returns_409() -> None:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -297,6 +297,41 @@ async def test_handler_exception_releases_slot() -> None:
     assert await store.get(IdempotencyKey("x")) is None
 
 
+async def test_oversized_body_passes_through_without_idempotency() -> None:
+    """Content-Length over max_body_bytes → handler runs, no slot recorded."""
+    store = InMemoryStore()
+    middleware = IdempotencyMiddleware(echo_app, store, max_body_bytes=100)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/", headers={"Idempotency-Key": "x"}, content=b"a" * 200,
+        )
+
+    assert response.status_code == 200
+    assert response.content == b"a" * 200
+    # Nothing was recorded — idempotency was skipped.
+    assert await store.get(IdempotencyKey("x")) is None
+
+
+async def test_undersized_body_uses_idempotency() -> None:
+    """Sanity: when Content-Length is within the limit, the slot is recorded."""
+    store = InMemoryStore()
+    middleware = IdempotencyMiddleware(echo_app, store, max_body_bytes=100)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        await client.post(
+            "/", headers={"Idempotency-Key": "x"}, content=b"a" * 50,
+        )
+
+    assert await store.get(IdempotencyKey("x")) is not None
+
+
 async def test_concurrent_request_with_same_key_returns_409() -> None:
     in_handler = asyncio.Event()
     can_finish = asyncio.Event()

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -6,6 +6,7 @@ edge cases like non-HTTP scope types.
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -153,3 +154,78 @@ async def test_first_post_stores_completed_record() -> None:
     assert record.response is not None
     assert record.response.status_code == 200
     assert record.response.body == b"hello"
+
+
+async def test_replay_returns_cached_response_with_replayed_header() -> None:
+    async with make_client(echo_app) as client:
+        first = await client.post(
+            "/", headers={"Idempotency-Key": "abc"}, content=b"hello",
+        )
+        second = await client.post(
+            "/", headers={"Idempotency-Key": "abc"}, content=b"hello",
+        )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.content == b"hello"
+    assert second.headers["idempotent-replayed"] == "true"
+
+
+async def test_same_key_different_body_returns_422() -> None:
+    async with make_client(echo_app) as client:
+        first = await client.post(
+            "/", headers={"Idempotency-Key": "abc"}, content=b"hello",
+        )
+        second = await client.post(
+            "/", headers={"Idempotency-Key": "abc"}, content=b"world",
+        )
+
+    assert first.status_code == 200
+    assert second.status_code == 422
+
+
+async def test_concurrent_request_with_same_key_returns_409() -> None:
+    in_handler = asyncio.Event()
+    can_finish = asyncio.Event()
+
+    async def slow_app(scope: Scope, receive: Receive, send: Send) -> None:
+        # Drain the request body so the middleware can buffer-and-replay.
+        while True:
+            message = await receive()
+            if message["type"] != "http.request":
+                break
+            if not message.get("more_body", False):
+                break
+
+        in_handler.set()
+        await can_finish.wait()
+
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            },
+        )
+        await send({"type": "http.response.body", "body": b"slow"})
+
+    async with make_client(slow_app) as client:
+
+        async def first() -> httpx.Response:
+            return await client.post(
+                "/", headers={"Idempotency-Key": "x"}, content=b"a",
+            )
+
+        async def second() -> httpx.Response:
+            await in_handler.wait()
+            try:
+                return await client.post(
+                    "/", headers={"Idempotency-Key": "x"}, content=b"a",
+                )
+            finally:
+                can_finish.set()
+
+        r1, r2 = await asyncio.gather(first(), second())
+
+    assert r1.status_code == 200
+    assert r2.status_code == 409

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,90 @@
+"""Acceptance tests for IdempotencyMiddleware.
+
+Tests use httpx.ASGITransport for HTTP cases and direct ASGI calls for
+edge cases like non-HTTP scope types.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from fastapi_idempotency import IdempotencyMiddleware, InMemoryStore
+
+if TYPE_CHECKING:
+    from starlette.types import Message, Receive, Scope, Send
+
+
+async def echo_app(scope: Scope, receive: Receive, send: Send) -> None:
+    """Minimal ASGI app: returns the request body, or 'ok' if empty."""
+    chunks: list[bytes] = []
+    while True:
+        message = await receive()
+        if message["type"] != "http.request":
+            break
+        chunks.append(message.get("body", b""))
+        if not message.get("more_body", False):
+            break
+
+    body = b"".join(chunks) or b"ok"
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"text/plain")],
+        },
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+def make_client(app: Any) -> httpx.AsyncClient:
+    middleware = IdempotencyMiddleware(app, InMemoryStore())
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    )
+
+
+async def test_get_passes_through_to_handler() -> None:
+    async with make_client(echo_app) as client:
+        response = await client.get("/")
+
+    assert response.status_code == 200
+    assert response.text == "ok"
+
+
+async def test_options_passes_through_to_handler() -> None:
+    async with make_client(echo_app) as client:
+        response = await client.options("/")
+
+    assert response.status_code == 200
+
+
+async def test_post_without_key_passes_through_to_handler() -> None:
+    async with make_client(echo_app) as client:
+        response = await client.post("/", content=b"hello")
+
+    assert response.status_code == 200
+    assert response.content == b"hello"
+
+
+async def test_non_http_scope_passes_through() -> None:
+    """Lifespan / websocket scopes should reach the wrapped app untouched."""
+    seen_scopes: list[str] = []
+
+    async def app(scope: Scope, _receive: Receive, _send: Send) -> None:
+        seen_scopes.append(scope["type"])
+
+    middleware = IdempotencyMiddleware(app, InMemoryStore())
+
+    async def _noop_receive() -> Message:
+        return {"type": "lifespan.startup"}
+
+    async def _noop_send(_message: Message) -> None:
+        return None
+
+    scope: Scope = {"type": "lifespan"}
+    await middleware(scope, _noop_receive, _noop_send)
+
+    assert seen_scopes == ["lifespan"]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -105,7 +105,9 @@ async def test_too_long_key_returns_400() -> None:
     long_key = "a" * 256
     async with make_client(echo_app) as client:
         response = await client.post(
-            "/", headers={"Idempotency-Key": long_key}, content=b"x",
+            "/",
+            headers={"Idempotency-Key": long_key},
+            content=b"x",
         )
 
     assert response.status_code == 400
@@ -125,7 +127,9 @@ async def test_empty_key_returns_400() -> None:
     """Empty header value fails the 1-255 length rule."""
     async with make_client(echo_app) as client:
         response = await client.post(
-            "/", headers={"Idempotency-Key": ""}, content=b"x",
+            "/",
+            headers={"Idempotency-Key": ""},
+            content=b"x",
         )
 
     assert response.status_code == 400
@@ -134,7 +138,9 @@ async def test_empty_key_returns_400() -> None:
 async def test_first_post_runs_handler_and_returns_response() -> None:
     async with make_client(echo_app) as client:
         response = await client.post(
-            "/", headers={"Idempotency-Key": "abc"}, content=b"hello",
+            "/",
+            headers={"Idempotency-Key": "abc"},
+            content=b"hello",
         )
 
     assert response.status_code == 200
@@ -150,7 +156,9 @@ async def test_first_post_stores_completed_record() -> None:
         base_url="http://testserver",
     ) as client:
         await client.post(
-            "/", headers={"Idempotency-Key": "abc"}, content=b"hello",
+            "/",
+            headers={"Idempotency-Key": "abc"},
+            content=b"hello",
         )
 
     record = await store.get(IdempotencyKey("abc"))
@@ -164,10 +172,14 @@ async def test_first_post_stores_completed_record() -> None:
 async def test_replay_returns_cached_response_with_replayed_header() -> None:
     async with make_client(echo_app) as client:
         first = await client.post(
-            "/", headers={"Idempotency-Key": "abc"}, content=b"hello",
+            "/",
+            headers={"Idempotency-Key": "abc"},
+            content=b"hello",
         )
         second = await client.post(
-            "/", headers={"Idempotency-Key": "abc"}, content=b"hello",
+            "/",
+            headers={"Idempotency-Key": "abc"},
+            content=b"hello",
         )
 
     assert first.status_code == 200
@@ -179,10 +191,14 @@ async def test_replay_returns_cached_response_with_replayed_header() -> None:
 async def test_same_key_different_body_returns_422() -> None:
     async with make_client(echo_app) as client:
         first = await client.post(
-            "/", headers={"Idempotency-Key": "abc"}, content=b"hello",
+            "/",
+            headers={"Idempotency-Key": "abc"},
+            content=b"hello",
         )
         second = await client.post(
-            "/", headers={"Idempotency-Key": "abc"}, content=b"world",
+            "/",
+            headers={"Idempotency-Key": "abc"},
+            content=b"world",
         )
 
     assert first.status_code == 200
@@ -193,7 +209,9 @@ async def test_5xx_response_releases_slot() -> None:
     """Server errors aren't cached — the slot is dropped so a retry runs fresh."""
 
     async def server_error_app(
-        _scope: Scope, receive: Receive, send: Send,
+        _scope: Scope,
+        receive: Receive,
+        send: Send,
     ) -> None:
         while True:
             message = await receive()
@@ -218,7 +236,9 @@ async def test_5xx_response_releases_slot() -> None:
         base_url="http://testserver",
     ) as client:
         response = await client.post(
-            "/", headers={"Idempotency-Key": "x"}, content=b"a",
+            "/",
+            headers={"Idempotency-Key": "x"},
+            content=b"a",
         )
 
     assert response.status_code == 500
@@ -230,7 +250,9 @@ async def test_5xx_then_retry_runs_handler_again() -> None:
     invocations = 0
 
     async def flaky_app(
-        _scope: Scope, receive: Receive, send: Send,
+        _scope: Scope,
+        receive: Receive,
+        send: Send,
     ) -> None:
         nonlocal invocations
         while True:
@@ -259,10 +281,14 @@ async def test_5xx_then_retry_runs_handler_again() -> None:
         base_url="http://testserver",
     ) as client:
         first = await client.post(
-            "/", headers={"Idempotency-Key": "x"}, content=b"a",
+            "/",
+            headers={"Idempotency-Key": "x"},
+            content=b"a",
         )
         second = await client.post(
-            "/", headers={"Idempotency-Key": "x"}, content=b"a",
+            "/",
+            headers={"Idempotency-Key": "x"},
+            content=b"a",
         )
 
     assert first.status_code == 500
@@ -275,7 +301,9 @@ async def test_handler_exception_releases_slot() -> None:
     """If the wrapped app raises before sending a response, release the slot."""
 
     async def boom_app(
-        _scope: Scope, receive: Receive, _send: Send,
+        _scope: Scope,
+        receive: Receive,
+        _send: Send,
     ) -> None:
         while True:
             message = await receive()
@@ -295,7 +323,9 @@ async def test_handler_exception_releases_slot() -> None:
     ) as client:
         with contextlib.suppress(Exception):
             await client.post(
-                "/", headers={"Idempotency-Key": "x"}, content=b"a",
+                "/",
+                headers={"Idempotency-Key": "x"},
+                content=b"a",
             )
 
     assert await store.get(IdempotencyKey("x")) is None
@@ -311,7 +341,9 @@ async def test_oversized_body_passes_through_without_idempotency() -> None:
         base_url="http://testserver",
     ) as client:
         response = await client.post(
-            "/", headers={"Idempotency-Key": "x"}, content=b"a" * 200,
+            "/",
+            headers={"Idempotency-Key": "x"},
+            content=b"a" * 200,
         )
 
     assert response.status_code == 200
@@ -330,7 +362,9 @@ async def test_undersized_body_uses_idempotency() -> None:
         base_url="http://testserver",
     ) as client:
         await client.post(
-            "/", headers={"Idempotency-Key": "x"}, content=b"a" * 50,
+            "/",
+            headers={"Idempotency-Key": "x"},
+            content=b"a" * 50,
         )
 
     assert await store.get(IdempotencyKey("x")) is not None
@@ -355,7 +389,8 @@ async def test_store_error_on_complete_adds_idempotency_stored_false_header() ->
             return await self._inner.acquire(key, fingerprint, ttl)
 
         async def get(
-            self, key: IdempotencyKey,
+            self,
+            key: IdempotencyKey,
         ) -> IdempotencyRecord | None:
             return await self._inner.get(key)
 
@@ -379,7 +414,9 @@ async def test_store_error_on_complete_adds_idempotency_stored_false_header() ->
         base_url="http://testserver",
     ) as client:
         response = await client.post(
-            "/", headers={"Idempotency-Key": "x"}, content=b"hello",
+            "/",
+            headers={"Idempotency-Key": "x"},
+            content=b"hello",
         )
 
     assert response.status_code == 200
@@ -394,7 +431,9 @@ async def test_in_flight_ttl_expiry_reclaims_orphaned_slot() -> None:
     invocations = 0
 
     async def slow_handler(
-        _scope: Scope, receive: Receive, send: Send,
+        _scope: Scope,
+        receive: Receive,
+        send: Send,
     ) -> None:
         nonlocal invocations
         while True:
@@ -417,7 +456,9 @@ async def test_in_flight_ttl_expiry_reclaims_orphaned_slot() -> None:
         )
 
     middleware = IdempotencyMiddleware(
-        slow_handler, InMemoryStore(), in_flight_ttl=0.02,
+        slow_handler,
+        InMemoryStore(),
+        in_flight_ttl=0.02,
     )
 
     async with httpx.AsyncClient(
@@ -427,13 +468,17 @@ async def test_in_flight_ttl_expiry_reclaims_orphaned_slot() -> None:
 
         async def first() -> httpx.Response:
             return await client.post(
-                "/", headers={"Idempotency-Key": "x"}, content=b"a",
+                "/",
+                headers={"Idempotency-Key": "x"},
+                content=b"a",
             )
 
         async def second_after_ttl() -> httpx.Response:
             await asyncio.sleep(0.05)  # > in_flight_ttl
             return await client.post(
-                "/", headers={"Idempotency-Key": "x"}, content=b"a",
+                "/",
+                headers={"Idempotency-Key": "x"},
+                content=b"a",
             )
 
         r1, r2 = await asyncio.gather(first(), second_after_ttl())
@@ -473,14 +518,18 @@ async def test_concurrent_request_with_same_key_returns_409() -> None:
 
         async def first() -> httpx.Response:
             return await client.post(
-                "/", headers={"Idempotency-Key": "x"}, content=b"a",
+                "/",
+                headers={"Idempotency-Key": "x"},
+                content=b"a",
             )
 
         async def second() -> httpx.Response:
             await in_handler.wait()
             try:
                 return await client.post(
-                    "/", headers={"Idempotency-Key": "x"}, content=b"a",
+                    "/",
+                    headers={"Idempotency-Key": "x"},
+                    content=b"a",
                 )
             finally:
                 can_finish.set()

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -88,3 +88,33 @@ async def test_non_http_scope_passes_through() -> None:
     await middleware(scope, _noop_receive, _noop_send)
 
     assert seen_scopes == ["lifespan"]
+
+
+async def test_too_long_key_returns_400() -> None:
+    long_key = "a" * 256
+    async with make_client(echo_app) as client:
+        response = await client.post(
+            "/", headers={"Idempotency-Key": long_key}, content=b"x",
+        )
+
+    assert response.status_code == 400
+    assert response.text == "invalid Idempotency-Key"
+
+
+async def test_non_ascii_key_returns_400() -> None:
+    # Bypass httpx's str-to-ASCII encoding by sending raw bytes.
+    headers = httpx.Headers([(b"Idempotency-Key", b"\xf1")])
+    async with make_client(echo_app) as client:
+        response = await client.post("/", headers=headers, content=b"x")
+
+    assert response.status_code == 400
+
+
+async def test_empty_key_returns_400() -> None:
+    """Empty header value fails the 1-255 length rule."""
+    async with make_client(echo_app) as client:
+        response = await client.post(
+            "/", headers={"Idempotency-Key": ""}, content=b"x",
+        )
+
+    assert response.status_code == 400

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -10,7 +10,12 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from fastapi_idempotency import IdempotencyMiddleware, InMemoryStore
+from fastapi_idempotency import (
+    IdempotencyKey,
+    IdempotencyMiddleware,
+    IdempotencyState,
+    InMemoryStore,
+)
 
 if TYPE_CHECKING:
     from starlette.types import Message, Receive, Scope, Send
@@ -118,3 +123,33 @@ async def test_empty_key_returns_400() -> None:
         )
 
     assert response.status_code == 400
+
+
+async def test_first_post_runs_handler_and_returns_response() -> None:
+    async with make_client(echo_app) as client:
+        response = await client.post(
+            "/", headers={"Idempotency-Key": "abc"}, content=b"hello",
+        )
+
+    assert response.status_code == 200
+    assert response.content == b"hello"
+
+
+async def test_first_post_stores_completed_record() -> None:
+    store = InMemoryStore()
+    middleware = IdempotencyMiddleware(echo_app, store)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        await client.post(
+            "/", headers={"Idempotency-Key": "abc"}, content=b"hello",
+        )
+
+    record = await store.get(IdempotencyKey("abc"))
+    assert record is not None
+    assert record.state is IdempotencyState.COMPLETED
+    assert record.response is not None
+    assert record.response.status_code == 200
+    assert record.response.body == b"hello"

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -387,6 +387,63 @@ async def test_store_error_on_complete_adds_idempotency_stored_false_header() ->
     assert response.headers["idempotency-stored"] == "false"
 
 
+async def test_in_flight_ttl_expiry_reclaims_orphaned_slot() -> None:
+    """Crash-orphan recovery: a handler that runs longer than in_flight_ttl
+    loses its slot, so the next request gets a fresh CREATED instead of
+    being blocked by IN_FLIGHT or MISMATCH."""
+    invocations = 0
+
+    async def slow_handler(
+        _scope: Scope, receive: Receive, send: Send,
+    ) -> None:
+        nonlocal invocations
+        while True:
+            message = await receive()
+            if message["type"] != "http.request":
+                break
+            if not message.get("more_body", False):
+                break
+        invocations += 1
+        await asyncio.sleep(0.1)
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            },
+        )
+        await send(
+            {"type": "http.response.body", "body": str(invocations).encode()},
+        )
+
+    middleware = IdempotencyMiddleware(
+        slow_handler, InMemoryStore(), in_flight_ttl=0.02,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+
+        async def first() -> httpx.Response:
+            return await client.post(
+                "/", headers={"Idempotency-Key": "x"}, content=b"a",
+            )
+
+        async def second_after_ttl() -> httpx.Response:
+            await asyncio.sleep(0.05)  # > in_flight_ttl
+            return await client.post(
+                "/", headers={"Idempotency-Key": "x"}, content=b"a",
+            )
+
+        r1, r2 = await asyncio.gather(first(), second_after_ttl())
+
+    # Both ran the handler — second wasn't blocked by the still-running first.
+    assert invocations == 2
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+
+
 async def test_concurrent_request_with_same_key_returns_409() -> None:
     in_handler = asyncio.Event()
     can_finish = asyncio.Event()

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -7,6 +7,7 @@ edge cases like non-HTTP scope types.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -182,6 +183,118 @@ async def test_same_key_different_body_returns_422() -> None:
 
     assert first.status_code == 200
     assert second.status_code == 422
+
+
+async def test_5xx_response_releases_slot() -> None:
+    """Server errors aren't cached — the slot is dropped so a retry runs fresh."""
+
+    async def server_error_app(
+        _scope: Scope, receive: Receive, send: Send,
+    ) -> None:
+        while True:
+            message = await receive()
+            if message["type"] != "http.request":
+                break
+            if not message.get("more_body", False):
+                break
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 500,
+                "headers": [(b"content-type", b"text/plain")],
+            },
+        )
+        await send({"type": "http.response.body", "body": b"oops"})
+
+    store = InMemoryStore()
+    middleware = IdempotencyMiddleware(server_error_app, store)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/", headers={"Idempotency-Key": "x"}, content=b"a",
+        )
+
+    assert response.status_code == 500
+    assert await store.get(IdempotencyKey("x")) is None
+
+
+async def test_5xx_then_retry_runs_handler_again() -> None:
+    """After 5xx, the slot is gone — a retry hits the handler, not REPLAY."""
+    invocations = 0
+
+    async def flaky_app(
+        _scope: Scope, receive: Receive, send: Send,
+    ) -> None:
+        nonlocal invocations
+        while True:
+            message = await receive()
+            if message["type"] != "http.request":
+                break
+            if not message.get("more_body", False):
+                break
+        invocations += 1
+        status = 500 if invocations == 1 else 200
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": [(b"content-type", b"text/plain")],
+            },
+        )
+        await send(
+            {"type": "http.response.body", "body": str(invocations).encode()},
+        )
+
+    middleware = IdempotencyMiddleware(flaky_app, InMemoryStore())
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        first = await client.post(
+            "/", headers={"Idempotency-Key": "x"}, content=b"a",
+        )
+        second = await client.post(
+            "/", headers={"Idempotency-Key": "x"}, content=b"a",
+        )
+
+    assert first.status_code == 500
+    assert second.status_code == 200
+    assert second.text == "2"
+    assert invocations == 2
+
+
+async def test_handler_exception_releases_slot() -> None:
+    """If the wrapped app raises before sending a response, release the slot."""
+
+    async def boom_app(
+        _scope: Scope, receive: Receive, _send: Send,
+    ) -> None:
+        while True:
+            message = await receive()
+            if message["type"] != "http.request":
+                break
+            if not message.get("more_body", False):
+                break
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    store = InMemoryStore()
+    middleware = IdempotencyMiddleware(boom_app, store)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        with contextlib.suppress(Exception):
+            await client.post(
+                "/", headers={"Idempotency-Key": "x"}, content=b"a",
+            )
+
+    assert await store.get(IdempotencyKey("x")) is None
 
 
 async def test_concurrent_request_with_same_key_returns_409() -> None:


### PR DESCRIPTION
Closes #3.

## What's in

Wires the store, body buffer, and fingerprint into a working ASGI
middleware. Implemented across nine focused commits.

### Public surface
- `IdempotencyMiddleware` — fully functional. Accepts `app`, `store`,
  plus `header_name` / `in_flight_ttl` / `completed_ttl` /
  `max_body_bytes` / `scope_factory` keyword args.
- `compute_fingerprint(method, path, query_string, body)` — SHA-256 over
  length-prefixed components; used internally by the middleware.

### Behavior
- **Pre-acquire gating** in `__call__`: non-HTTP scopes (lifespan /
  websocket), safe methods (GET/HEAD/OPTIONS), missing
  `Idempotency-Key` header, and oversized bodies (Content-Length
  pre-check) all pass through untouched.
- **Validation**: malformed keys (empty, > 255 chars, non-ASCII) →
  `400 Bad Request`.
- **Acquire-outcome dispatch** in `_handle_intercepted`:
  - `CREATED` → run handler with the buffered replay-receive, emit the
    captured response, `store.complete` with `completed_ttl`.
  - `REPLAY` → emit cached response with an `Idempotent-Replayed: true`
    header.
  - `IN_FLIGHT` → `409 Conflict`.
  - `MISMATCH` → `422 Unprocessable Entity`.
- **Failure modes**:
  - 5xx response or no response → `store.release` (slot dropped, retry
    runs fresh).
  - Handler exception → `store.release` then propagate.
  - `store.complete` raises `StoreError` → response delivered with
    `Idempotency-Stored: false` header (per the deferred decision in #3).

### Architectural choice worth flagging
`_ResponseCapturer` was originally a "forward-as-it-captures" wrapper.
It became a pure buffer because amending headers (specifically the
`Idempotency-Stored: false` fallback) requires deciding on
complete/release **after** the handler finishes. Streaming response
support is now an explicit v0.2.0 decision, not an accidental property.

## Acceptance criteria

- [x] All ten acceptance tests pass (httpx.ASGITransport + direct ASGI).
- [x] 95%+ line/branch coverage on `middleware.py` — exactly 95% (125
      stmts, 5 miss, 34 branches, 3 partial; the misses are the
      defensive 500 path for the "REPLAY but record.response is None"
      case which is unreachable per the Store contract).
- [x] `mypy --strict src tests` — clean.
- [x] `ruff check src tests` — clean.
- [x] 50 tests total across the suite (13 store + 9 body-buffer + 8
      fingerprint + 18 middleware + 1 version + 1 package).

## Deferred (intentionally out of scope)

Found during review of the merged work but kept out of this PR to keep
issue #3 focused on middleware functionality. All tracked in #4 under
"Pre-release polish":

- Decide the fate of `scope_factory` (currently dead parameter).
- Unify `_send_plain_response` and `_emit_captured`.
- Extract `_get_header(scope, name)` helper.
- Narrow the public API surface.

Security / robustness items deferred to v0.2.0 (out of v0.1.0 scope):

- HMAC fingerprint to defend against probing attacks.
- 413 instead of 500 when chunked-transfer overruns `max_body_bytes`.
- Hash idempotency keys before logging.
- LRU eviction cap in `InMemoryStore` (planned for v0.3.0 per roadmap).

## Verification

- `pytest` — 50 passed
- `mypy --strict src tests` — clean
- `ruff check src tests` — clean