### PR TITLE
chore(middleware): remove unimplemented scope_factory parameter

### DIFF
--- a/src/fastapi_idempotency/__init__.py
+++ b/src/fastapi_idempotency/__init__.py
@@ -9,7 +9,7 @@ from .errors import (
     RequestTooLargeError,
     StoreError,
 )
-from .middleware import IdempotencyMiddleware, ScopeFactory
+from .middleware import IdempotencyMiddleware
 from .store import Store
 from .stores.memory import InMemoryStore
 from .types import (
@@ -38,7 +38,6 @@ __all__ = [
     "IdempotencyState",
     "InMemoryStore",
     "RequestTooLargeError",
-    "ScopeFactory",
     "Store",
     "StoreError",
     "__version__",

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -3,10 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, ClassVar, TypeAlias
-
-from starlette.requests import Request
+from typing import TYPE_CHECKING, ClassVar
 
 from .body_buffer import buffer_request_body
 from .errors import StoreError
@@ -24,14 +21,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-
-ScopeFactory: TypeAlias = Callable[[Request], str | Awaitable[str]]
-"""Function that derives a scope string (e.g. tenant, user) from the request.
-
-Called by the middleware before key lookup; the result is prefixed onto
-the idempotency key so different scopes don't collide.
-"""
 
 
 class IdempotencyMiddleware:
@@ -58,7 +47,6 @@ class IdempotencyMiddleware:
         in_flight_ttl: float = 30.0,
         completed_ttl: float = 86_400.0,
         max_body_bytes: int | None = None,
-        scope_factory: ScopeFactory | None = None,
     ) -> None:
         self.app = app
         self.store = store
@@ -66,7 +54,6 @@ class IdempotencyMiddleware:
         self.in_flight_ttl = in_flight_ttl
         self.completed_ttl = completed_ttl
         self.max_body_bytes = max_body_bytes
-        self.scope_factory = scope_factory
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":


### PR DESCRIPTION
Refs #4 (pre-release polish).

## Why

\`scope_factory\` is accepted as a constructor argument but never invoked
— pure forward-compatibility for v0.3.0's per-user scoping. A dead
parameter is a footgun: users see it in autocomplete and reasonably
expect it to work.

## What changes

- Remove \`ScopeFactory\` type alias from \`middleware.py\`.
- Remove \`scope_factory\` constructor parameter and instance attribute.
- Remove \`ScopeFactory\` from \`fastapi_idempotency\` package re-exports.
- Drop now-unused imports (\`Awaitable\`, \`Callable\`, \`TypeAlias\`,
  \`starlette.requests.Request\`).

## Backwards compatibility

The package hasn't been published yet (still \`0.1.0.dev0\`); no released
version ever exposed a working \`scope_factory\`. Adding it back as a
real feature in v0.3.0 will be non-breaking — defaults to None.

## Verification

- \`pytest\` — 50 passed
- \`mypy --strict src tests\` — clean
- \`ruff check src tests\` — clean
- \`ruff format --check .\` — clean