### PR TITLE
refactor(middleware): extract _get_header helper

### DIFF
--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -205,12 +205,8 @@ class IdempotencyMiddleware:
         )
 
     def _extract_key(self, scope: Scope) -> str | None:
-        target = self.header_name.lower().encode("latin-1")
-        headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
-        for name, value in headers:
-            if name.lower() == target:
-                return value.decode("latin-1")
-        return None
+        raw = self._get_header(scope, self.header_name.encode("latin-1"))
+        return raw.decode("latin-1") if raw is not None else None
 
     def _is_valid_key(self, value: str) -> bool:
         # Per IETF draft: ASCII, 1..MAX_KEY_LENGTH chars.
@@ -222,15 +218,29 @@ class IdempotencyMiddleware:
         # mid-buffer, so this header is the only fence we trust.
         if self.max_body_bytes is None:
             return False
+        raw = self._get_header(scope, b"content-length")
+        if raw is None:
+            return False
+        try:
+            declared = int(raw)
+        except ValueError:
+            return False
+        return declared > self.max_body_bytes
+
+    @staticmethod
+    def _get_header(scope: Scope, name: bytes) -> bytes | None:
+        """Return the first header matching ``name`` (case-insensitive).
+
+        ASGI delivers headers as a list of ``(bytes, bytes)`` tuples
+        with names lowercased by the server, but lower-casing both sides
+        keeps the helper safe regardless of the caller's input.
+        """
+        target = name.lower()
         headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
-        for name, value in headers:
-            if name.lower() == b"content-length":
-                try:
-                    declared = int(value)
-                except ValueError:
-                    return False
-                return declared > self.max_body_bytes
-        return False
+        for header_name, header_value in headers:
+            if header_name.lower() == target:
+                return header_value
+        return None
 
     @staticmethod
     async def _send_response(


### PR DESCRIPTION
Refs #4 (pre-release polish).

## Why

\`_extract_key\` and \`_content_length_exceeds_limit\` both walk
\`scope['headers']\` and do case-insensitive matching against a target
name. Two places, one pattern — drift-prone if a third caller appears.

## What changes

New \`_get_header(scope, name) -> bytes | None\` static helper. Returns
the raw bytes of the first matching header, or None.

Both call sites collapse to a single line plus their domain-specific
decode/parse step:

- \`_extract_key\` — get header bytes, decode latin-1.
- \`_content_length_exceeds_limit\` — get header bytes, parse int,
  compare to limit.

## Behavior

Unchanged. 50 tests still pass, coverage on \`middleware.py\` stays at
95%.

## Verification

- \`pytest\` — 50 passed
- \`mypy --strict src tests\` — clean
- \`ruff check src tests\` — clean
- \`ruff format --check .\` — clean