### PR TITLE
chore(api): narrow __all__ to typical-user surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,11 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["PLR2004", "S101"]
 
+[tool.ruff.lint.isort]
+# Keep `from x import (A as A, B as B)` re-exports in a single block instead
+# of splitting them onto separate from-lines.
+combine-as-imports = true
+
 [tool.mypy]
 python_version = "3.10"
 strict = true

--- a/src/fastapi_idempotency/__init__.py
+++ b/src/fastapi_idempotency/__init__.py
@@ -1,4 +1,16 @@
-"""fastapi-idempotency: ``Idempotency-Key`` middleware for FastAPI / Starlette."""
+"""fastapi-idempotency: ``Idempotency-Key`` middleware for FastAPI / Starlette.
+
+Public API (the names listed in ``__all__``) is what most users need:
+the middleware, the in-memory store, the ``Store`` Protocol for custom
+backends, and the exception hierarchy for catch blocks.
+
+Store-implementation details (``AcquireOutcome``, ``AcquireResult``,
+``IdempotencyRecord``, ``IdempotencyState``, ``CachedResponse``,
+``IdempotencyKey``, ``Fingerprint``) are still importable from this
+module for users writing custom ``Store`` implementations, but are kept
+out of ``__all__`` to signal that they are advanced surface — not what
+a typical caller reaches for.
+"""
 
 from __future__ import annotations
 
@@ -13,29 +25,22 @@ from .middleware import IdempotencyMiddleware
 from .store import Store
 from .stores.memory import InMemoryStore
 from .types import (
-    AcquireOutcome,
-    AcquireResult,
-    CachedResponse,
-    Fingerprint,
-    IdempotencyKey,
-    IdempotencyRecord,
-    IdempotencyState,
+    AcquireOutcome as AcquireOutcome,
+    AcquireResult as AcquireResult,
+    CachedResponse as CachedResponse,
+    Fingerprint as Fingerprint,
+    IdempotencyKey as IdempotencyKey,
+    IdempotencyRecord as IdempotencyRecord,
+    IdempotencyState as IdempotencyState,
 )
 
 __version__ = "0.1.0.dev0"
 
 __all__ = [
-    "AcquireOutcome",
-    "AcquireResult",
-    "CachedResponse",
     "ConflictError",
-    "Fingerprint",
     "FingerprintMismatchError",
     "IdempotencyError",
-    "IdempotencyKey",
     "IdempotencyMiddleware",
-    "IdempotencyRecord",
-    "IdempotencyState",
     "InMemoryStore",
     "RequestTooLargeError",
     "Store",


### PR DESCRIPTION
Refs #4 (pre-release polish).

## Why

Pre-narrowing, \`__all__\` listed 16 names — including store-implementation
details (\`AcquireOutcome\`, \`IdempotencyRecord\`, etc.) that 90% of users
don't need. Wider \`__all__\` means noisier IDE autocomplete and a less
clear "what's the public API?" signal.

## What changes

\`__all__\` shrinks to 9 names — the typical-user surface:

\`\`\`python
__all__ = [
    "ConflictError",
    "FingerprintMismatchError",
    "IdempotencyError",
    "IdempotencyMiddleware",
    "InMemoryStore",
    "RequestTooLargeError",
    "Store",
    "StoreError",
    "__version__",
]
\`\`\`

The seven dropped names — \`AcquireOutcome\`, \`AcquireResult\`,
\`CachedResponse\`, \`Fingerprint\`, \`IdempotencyKey\`, \`IdempotencyRecord\`,
\`IdempotencyState\` — stay **importable** from \`fastapi_idempotency\` via
PEP 484 explicit re-exports (\`from .types import X as X\`). They're
still part of the runtime surface; just not advertised in \`__all__\` and
not surfaced by \`dir()\` / IDE autocomplete.

The choice: explicit re-exports satisfy mypy \`--strict\`'s
\`--no-implicit-reexport\` rule without polluting the typical-user surface.

## Tooling

\`combine-as-imports = true\` added to ruff isort config so the seven
\`as X as X\` re-exports stay in one from-block instead of being split
to seven separate blocks (the default isort behavior for renamed
imports).

## Subpackage move (\`fastapi_idempotency.advanced\`) was not chosen

That would have been a stronger signal but a real breaking change for
anyone already importing from the package root. \`__all__\` narrowing is
zero-cost and reversible — if v0.2.0 wants the subpackage, we do it then.

## Verification

- \`pytest\` — 50 passed
- \`mypy --strict src tests\` — clean
- \`ruff check src tests\` — clean
- \`ruff format --check .\` — clean