### PR TITLE
release: v0.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,7 @@ jobs:
       - name: mypy --strict
         run: uv run mypy src tests
       - name: pytest
-        # TODO(v0.1.0): drop --cov-fail-under=0 once real tests land; pyproject enforces 95%.
-        run: uv run pytest --cov --cov-fail-under=0 -m "not redis"
+        run: uv run pytest --cov -m "not redis"
       - name: pip-audit
         # Audit only what users will install: runtime deps + optional extras.
         # Dev tools (pip-audit, pytest, mypy, ruff) are excluded — their CVEs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.0] - 2026-04-30
+
+### Added
+
+- `IdempotencyMiddleware` — ASGI middleware enforcing `Idempotency-Key`
+  semantics on POST/PATCH/PUT/DELETE.
+- `Store` Protocol — pluggable storage contract.
+- `InMemoryStore` — single-process backend (asyncio.Lock + dict).
+- Body-fingerprint detection of key reuse with altered payloads
+  (responds 422).
+- Two-phase TTL: short `in_flight_ttl` (default 30s) + long
+  `completed_ttl` (default 24h).
+- Replay path with `Idempotent-Replayed: true` response header.
+- 5xx and exception responses release the slot for retry.
+- `Idempotency-Stored: false` header when storage fails after the
+  handler succeeds.
+- `max_body_bytes` pre-check via `Content-Length` to skip idempotency
+  on oversized bodies.
+- Domain exceptions: `IdempotencyError`, `ConflictError`,
+  `FingerprintMismatchError`, `StoreError`, `RequestTooLargeError`.
+
+### Known limitations
+
+- `InMemoryStore` is single-process only — multi-worker deployments
+  need a distributed backend.
+- `RedisStore` exists as a stub; real implementation lands in v0.2.0.
+- Streaming response pass-through deferred to v0.2.0 (responses are
+  fully buffered in memory).
+- No `scope_factory` / per-user scoping yet — planned for v0.3.0.
+- No HMAC fingerprint; deterministic SHA-256 — same key + same body
+  observable across requests in the same scope.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,80 @@
 
 **Pre-release / experimental.** The public API is not stable; expect breaking changes before v0.2.0. Do not use in production yet.
 
+## Quickstart
+
+Install (the package is on TestPyPI while in pre-release):
+
+```bash
+pip install -i https://test.pypi.org/simple/ fastapi-idempotency
+```
+
+### FastAPI
+
+```python
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from fastapi_idempotency import IdempotencyMiddleware, InMemoryStore
+
+
+class Order(BaseModel):
+    item_id: int
+    quantity: int
+
+
+app = FastAPI()
+app.add_middleware(IdempotencyMiddleware, store=InMemoryStore())
+
+
+@app.post("/orders")
+async def create_order(order: Order) -> dict[str, int]:
+    # Your business logic — runs at most once per Idempotency-Key.
+    return {"id": 42, "item_id": order.item_id}
+```
+
+Send the same request twice with `Idempotency-Key: abc-123`:
+
+- The first call runs the handler and returns `{"id": 42, ...}`.
+- The second call returns the same body with `Idempotent-Replayed: true` —
+  no second insert, no second charge.
+
+### Starlette
+
+```python
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from fastapi_idempotency import IdempotencyMiddleware, InMemoryStore
+
+
+async def create_order(request):
+    body = await request.json()
+    return JSONResponse({"id": 42, "item_id": body["item_id"]})
+
+
+app = Starlette(routes=[Route("/orders", create_order, methods=["POST"])])
+app = IdempotencyMiddleware(app, InMemoryStore())
+```
+
+## How it works
+
+The middleware watches non-safe HTTP methods (POST/PATCH/PUT/DELETE) for
+the `Idempotency-Key` header. Outcomes:
+
+| Situation | What the client sees |
+| --- | --- |
+| First request with a given key | Handler runs; response is returned and cached. |
+| Same key + same body, while the first is still in flight | `409 Conflict` |
+| Same key + same body, after the first completed | Cached response with `Idempotent-Replayed: true` header |
+| Same key + different body | `422 Unprocessable Entity` |
+| Handler returned 5xx | Slot released; a retry will run the handler again. |
+| Handler succeeded but the store failed to persist | Response delivered with `Idempotency-Stored: false` header |
+
+Safe methods (GET/HEAD/OPTIONS), requests without an `Idempotency-Key`,
+and requests over `max_body_bytes` pass through untouched.
+
 ## Roadmap
 
 - **v0.1.0** — minimal working version: in-memory store, middleware core, fingerprint, two-phase TTL, replay path, basic error handling. Publish to TestPyPI.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -51,7 +51,59 @@ every call with `try/except`.
 
 ## Body fingerprint scope
 
-_To be written during v0.1.0._
+**Status: v0.1.0.**
+
+Fingerprint is computed over `method + path + query_string + body`,
+length-prefixed and SHA-256 hashed. Each component carries
+request-identity that the body alone doesn't.
+
+### Why include each piece
+
+- **Body**: the obvious one — same key with different payload should
+  reject (`422 MISMATCH`). Without body in the fingerprint, an attacker
+  who guessed someone's `Idempotency-Key` could submit a different body
+  and get the original response replayed.
+- **Path**: `POST /charges` and `POST /refunds` carrying the same body
+  are different operations. A naive client might reuse a key across
+  them; the path-level distinction prevents accidental cross-endpoint
+  collision.
+- **Method**: `POST /resource` and `DELETE /resource` are different
+  intents. Including method makes the fingerprint match exactly one
+  semantic operation.
+- **Query string**: typically carries semantics (`?dry_run=true`,
+  `?tenant=acme`, pagination cursors). Two requests differing only in
+  query parameters are different operations and should not collide.
+
+### Why length-prefix each component
+
+Naive concatenation is ambiguous when component boundaries fall
+anywhere in the byte stream. Body bytes are fully attacker-controlled
+and can mimic the tail of any other component. For instance:
+
+- `path="/orders/12"` + `body=b"3"`
+- `path="/orders/123"` + `body=b""`
+
+Both yield the byte stream `"/orders/123"` after concatenation —
+identical hash, despite being different requests. Length-prefixing
+each component before feeding it to the hasher makes the boundary
+explicit, so prefix-aligned splits cannot collide.
+
+(The same is true in theory for `method`/`path` boundaries, but in
+practice HTTP methods are a fixed alphabet validated by the server
+before middleware runs — that boundary isn't attacker-reachable.
+Body is.)
+
+### What is _not_ in the fingerprint
+
+- **Headers** (other than `Idempotency-Key` itself): too volatile.
+  `User-Agent`, `Accept-Language`, `X-Request-ID` would all change
+  per-retry and break the matching guarantee. If header-based identity
+  matters (e.g. tenant via `X-Tenant-Id`), use a `scope_factory`
+  (planned for v0.3.0).
+- **Time / nonce**: the whole point is determinism — two identical
+  requests must produce the same fingerprint.
+- **Source IP**: same reasoning as headers — too volatile and not
+  intent-bearing.
 
 ## Streaming response pass-through
 

--- a/src/fastapi_idempotency/__init__.py
+++ b/src/fastapi_idempotency/__init__.py
@@ -34,7 +34,7 @@ from .types import (
     IdempotencyState as IdempotencyState,
 )
 
-__version__ = "0.1.0.dev0"
+__version__ = "0.1.0"
 
 __all__ = [
     "ConflictError",

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -2,4 +2,4 @@ from fastapi_idempotency import __version__
 
 
 def test_version_exported() -> None:
-    assert __version__ == "0.1.0.dev0"
+    assert __version__ == "0.1.0"


### PR DESCRIPTION
Closes #4.

Final PR of the v0.1.0 milestone. Five docs + config commits prepare the
package for TestPyPI publication. Mechanical steps (tag, build, upload,
GitHub Release) are run manually by the maintainer per the checklist in
issue #4.

## Commits

| Commit | What |
| --- | --- |
| \`da1d1bf\` | CHANGELOG \`[0.1.0]\` — Added (10 features) + Known limitations (5 honest items, including security gaps deferred to v0.2.0) |
| \`b014925\` | README Quickstart (FastAPI + pydantic primary, Starlette secondary) + "How it works" outcome table |
| \`a6a72ce\` | DESIGN.md "Body fingerprint scope" — why \`method+path+query+body\`, why length-prefix, what's deliberately excluded |
| \`ce89179\` | Version bump \`0.1.0.dev0\` → \`0.1.0\` (single source of truth in \`__init__.py\`, hatchling reads it) |
| \`913389a\` | Drop \`--cov-fail-under=0\` from CI — the 95% gate from \`pyproject.toml\` is now actually enforced |

Total: 6 files changed, +162 / -5.

## Coverage

| | Before this PR | After this PR |
| --- | --- | --- |
| CI gate enforced? | No (\`--cov-fail-under=0\` override) | **Yes** (95% from pyproject) |
| Total coverage | 97% | **97.41%** |
| Margin above gate | n/a | +2.4 points |

## Pre-release polish (issue #4) — all six PRs landed

| # | PR | What |
| --- | --- | --- |
| 1 | #9 | Removed unimplemented \`scope_factory\` (footgun) |
| 2 | #10 | Unified response emission via \`_send_response\` primitive |
| 3 | #11 | Extracted \`_get_header\` header-lookup helper |
| 4 | #12 | Narrowed \`__all__\` to typical-user surface |
| 5 | #13 | \`# pragma: no cover\` on RedisStore stub + import smoke test |
| 6 | _this PR_ | Release docs + version + CI gate |

## Verification

- \`pytest --cov -m "not redis"\` — 51 passed, **coverage 97.41% (gate 95%)**
- \`mypy --strict src tests\` — clean (16 source files)
- \`ruff check src tests\` — clean
- \`ruff format --check .\` — clean
- \`uv build\` — produces \`fastapi_idempotency-0.1.0.tar.gz\` and
  \`fastapi_idempotency-0.1.0-py3-none-any.whl\`. Wheel METADATA reports
  \`Version: 0.1.0\`, includes \`py.typed\`.

## What still happens manually after merge (issue #4 release checklist)

- [ ] \`git tag -a v0.1.0 -m "v0.1.0"\` + \`git push --tags\`
- [ ] \`uv build\` (rebuild from tagged commit)
- [ ] \`uv publish --index testpypi\` (requires token, out of CI)
- [ ] Fresh-install smoke test in a clean venv
- [ ] Draft + publish GitHub Release pointing at the tag

Trusted Publishing GitHub Action is deliberately deferred to v0.2.0
release prep — overkill for a TestPyPI alpha.