### PR TITLE
fix(readme): use --extra-index-url for TestPyPI install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,14 @@
 Install (the package is on TestPyPI while in pre-release):
 
 ```bash
-pip install -i https://test.pypi.org/simple/ fastapi-idempotency
+pip install \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  fastapi-idempotency
 ```
+
+`--extra-index-url` lets pip resolve runtime dependencies (`starlette`,
+`msgpack`) from real PyPI, since TestPyPI mirrors only this package.
 
 ### FastAPI
 


### PR DESCRIPTION
## Why

Caught during the v0.1.0 smoke test in a clean venv: the previous
\`pip install -i https://test.pypi.org/simple/ fastapi-idempotency\`
**fails** in practice because TestPyPI doesn't mirror runtime deps —
it only contains this project.

Users following the README would have seen:

\`\`\`text
ERROR: Could not find a version that satisfies the requirement starlette>=0.37
\`\`\`

## What changes

The install snippet now resolves the project from TestPyPI and its deps
from real PyPI:

\`\`\`bash
pip install \\
  --index-url https://test.pypi.org/simple/ \\
  --extra-index-url https://pypi.org/simple/ \\
  fastapi-idempotency
\`\`\`

One-line note added explaining \`--extra-index-url\` so it doesn't read
as an opaque incantation.

## Verification

Smoke-tested end-to-end in \`/tmp/fastapi-idempotency-smoke\` venv:

- Install with the new command succeeds.
- \`import fastapi_idempotency\` → \`__version__ == "0.1.0"\`.
- Public API (9 names from \`__all__\`) all importable.
- README's FastAPI quickstart, run via \`httpx.ASGITransport\`:
  - First POST: \`200\`, no replay header.
  - Second POST (same body): \`200\` + \`Idempotent-Replayed: true\`.
  - Different body, same key: \`422\`.

## Tag plan

\`v0.1.0\` tag currently points at the merge of #15. After this merges,
the README in tagged-source still has the broken command. Plan: re-tag
\`v0.1.0\` on this fix's merge commit (force-update tag) so the source
at \`v0.1.0\` matches reality. The TestPyPI artifacts themselves are
\*\*not\*\* republished — only docs change.