### PR TITLE
feat(redis-store): RedisStore backend with atomic Lua acquire + cross-store conformance suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
         run: uv run ruff format --check .
       - name: mypy --strict
         run: uv run mypy src tests
+      - name: pytest (InMemory — independent of redis service)
+        # Runs first so a broken redis service container produces a clean
+        # "redis-only failure" signal instead of red-everything: InMemory
+        # tests still pass even if the next step can't reach Redis.
+        run: uv run pytest -m "not redis"
       - name: pytest (full suite + coverage)
         # Runs everything including @pytest.mark.redis and @pytest.mark.slow
         # against the redis service container above. Coverage gate (95%)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,39 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          enable-cache: true
-      - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: uv sync --frozen --all-extras --dev --python ${{ matrix.python-version }}
-      - name: ruff check
-        run: uv run ruff check .
-      - name: ruff format --check
-        run: uv run ruff format --check .
-      - name: mypy --strict
-        run: uv run mypy src tests
-      - name: pytest (InMemory only)
-        # Coverage gate lives in the check-redis job (which exercises
-        # RedisStore against a real Redis); this matrix proves the
-        # InMemory + middleware path on every supported Python.
-        run: uv run pytest -m "not redis"
-      - name: pip-audit
-        # Audit only what users will install: runtime deps + optional extras.
-        # Dev tools (pip-audit, pytest, mypy, ruff) are excluded — their CVEs
-        # don't ship to library consumers. --disable-pip: resolver reads
-        # pinned+hashed requirements, no network resolve.
-        run: |
-          uv export --frozen --no-emit-project --no-dev --all-extras --format requirements-txt \
-            | uv run pip-audit --strict --disable-pip -r /dev/stdin
-
-  check-redis:
-    runs-on: ubuntu-latest
-    needs: check
     services:
       redis:
         image: redis:7.2-alpine
@@ -75,13 +42,28 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true
-      - name: Set up Python 3.13
-        run: uv python install 3.13
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv sync --frozen --all-extras --dev --python 3.13
+        run: uv sync --frozen --all-extras --dev --python ${{ matrix.python-version }}
+      - name: ruff check
+        run: uv run ruff check .
+      - name: ruff format --check
+        run: uv run ruff format --check .
+      - name: mypy --strict
+        run: uv run mypy src tests
       - name: pytest (full suite + coverage)
-        # Runs everything including @pytest.mark.redis and @pytest.mark.slow.
-        # This is the gate for the 95% coverage threshold — ``RedisStore``
-        # is only exercised here, so this is the only job that can honestly
-        # measure full-package coverage.
+        # Runs everything including @pytest.mark.redis and @pytest.mark.slow
+        # against the redis service container above. Coverage gate (95%)
+        # is enforced on every Python version — RedisStore parity bugs
+        # specific to 3.10/3.11/3.12 (e.g. async-semantics drift,
+        # redis-py edge cases) get caught here rather than at upgrade time.
         run: uv run pytest --cov
+      - name: pip-audit
+        # Audit only what users will install: runtime deps + optional extras.
+        # Dev tools (pip-audit, pytest, mypy, ruff) are excluded — their CVEs
+        # don't ship to library consumers. --disable-pip: resolver reads
+        # pinned+hashed requirements, no network resolve.
+        run: |
+          uv export --frozen --no-emit-project --no-dev --all-extras --format requirements-txt \
+            | uv run pip-audit --strict --disable-pip -r /dev/stdin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,11 @@ jobs:
         run: uv run ruff format --check .
       - name: mypy --strict
         run: uv run mypy src tests
-      - name: pytest
-        run: uv run pytest --cov -m "not redis"
+      - name: pytest (InMemory only)
+        # Coverage gate lives in the check-redis job (which exercises
+        # RedisStore against a real Redis); this matrix proves the
+        # InMemory + middleware path on every supported Python.
+        run: uv run pytest -m "not redis"
       - name: pip-audit
         # Audit only what users will install: runtime deps + optional extras.
         # Dev tools (pip-audit, pytest, mypy, ruff) are excluded — their CVEs
@@ -46,3 +49,39 @@ jobs:
         run: |
           uv export --frozen --no-emit-project --no-dev --all-extras --format requirements-txt \
             | uv run pip-audit --strict --disable-pip -r /dev/stdin
+
+  check-redis:
+    runs-on: ubuntu-latest
+    needs: check
+    services:
+      redis:
+        image: redis:7.2-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    env:
+      # Bypass testcontainers via REDIS_URL; the service container above
+      # publishes 6379 on the runner's localhost. REDIS_TESTS_REQUIRED=1
+      # ensures a connectivity issue is a hard fail, not a silent skip.
+      REDIS_URL: redis://localhost:6379
+      REDIS_TESTS_REQUIRED: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - name: Set up Python 3.13
+        run: uv python install 3.13
+      - name: Install dependencies
+        run: uv sync --frozen --all-extras --dev --python 3.13
+      - name: pytest (full suite + coverage)
+        # Runs everything including @pytest.mark.redis and @pytest.mark.slow.
+        # This is the gate for the 95% coverage threshold — ``RedisStore``
+        # is only exercised here, so this is the only job that can honestly
+        # measure full-package coverage.
+        run: uv run pytest --cov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `InMemoryStore.complete` now raises `StoreError` on expired records
+  (matching `RedisStore` and the `Store` protocol contract). Previously
+  it silently overwrote the expired in-flight slot with a fresh
+  `COMPLETED` record, masking the `in_flight_ttl` tuning signal
+  operators are supposed to see (#17).
+
 ## [0.1.0] - 2026-04-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- CI now splits into a matrix `check` job (Python 3.10–3.13: ruff,
-  mypy, `pytest -m "not redis"`, pip-audit) and a single-Python
-  `check-redis` job that runs the full suite with coverage against a
-  Redis service container. The 95% coverage gate now lives in the
-  redis job (it's the only job that exercises `RedisStore`).
+- CI matrix now runs the full test suite (including `@pytest.mark.redis`
+  and `@pytest.mark.slow`) against a Redis service container on every
+  Python version (3.10–3.13). The 95% coverage gate fires on every
+  matrix job — RedisStore parity bugs specific to a single Python
+  version get caught at PR time rather than at upgrade time.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `RedisStore` — distributed `Store` backend backed by Redis (#17).
+  Atomic `acquire` via a single Lua `EVAL` so concurrent workers cannot
+  double-claim a key; `get` / `complete` / `release` are straightforward
+  HSET/HGET/DEL paths. Requires the new `[redis]` extra
+  (`pip install fastapi-idempotency[redis]`); `RedisStore` is exposed
+  lazily on the package root so the bare install path stays free of
+  the redis-py dependency. Defense-in-depth Python-side `is_expired`
+  filter on `get` and `complete` covers the sub-millisecond race
+  between `PEXPIRE` and `HGET`.
+- msgpack record codec (`stores._serde`) with a v1 envelope, schema
+  versioning, and bounded payload size — used by `RedisStore` to
+  serialize `IdempotencyRecord` to bytes.
+- Cross-store conformance suite (`tests/test_stores_conformance.py`) —
+  parametrized over both backends so any Store-protocol drift between
+  `InMemoryStore` and `RedisStore` (or future implementations) is
+  caught by one test run. Covers acquire/get/complete/release
+  classification, identity preservation, state-machine edges, single-
+  process concurrency (`asyncio.gather` of 10 coros), and TTL expiry
+  under `asyncio.sleep`. Slow tests carry `@pytest.mark.slow`; redis
+  variants carry `@pytest.mark.redis`.
+- Cross-process concurrent-acquire test
+  (`tests/test_stores_redis_concurrent.py`): N OS processes via
+  `ProcessPoolExecutor(spawn)` with a `Manager().Barrier` so all
+  workers race simultaneously — the distributed-locking property that
+  justifies the Redis dependency.
+- `REDIS_URL` env var in `tests/conftest.py` bypasses testcontainers
+  for CI service containers and broken-Docker-bridge hosts; defaults
+  to DB 15 to keep `FLUSHDB` blast radius off operators' DB 0.
+- `REDIS_TESTS_REQUIRED=1` flips the redis-tests-skipped path into a
+  hard fail (used by the new `check-redis` CI job).
+
+### Changed
+
+- CI now splits into a matrix `check` job (Python 3.10–3.13: ruff,
+  mypy, `pytest -m "not redis"`, pip-audit) and a single-Python
+  `check-redis` job that runs the full suite with coverage against a
+  Redis service container. The 95% coverage gate now lives in the
+  redis job (it's the only job that exercises `RedisStore`).
+
 ### Fixed
 
 - `InMemoryStore.complete` now raises `StoreError` on expired records

--- a/README.md
+++ b/README.md
@@ -71,6 +71,49 @@ app = Starlette(routes=[Route("/orders", create_order, methods=["POST"])])
 app = IdempotencyMiddleware(app, InMemoryStore())
 ```
 
+### Redis (multi-worker / multi-process)
+
+`InMemoryStore` is single-process. For multi-worker deployments
+(uvicorn `--workers > 1`, gunicorn, k8s replicas) use `RedisStore` so
+all workers see the same idempotency state.
+
+Install with the `[redis]` extra:
+
+```bash
+pip install \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  'fastapi-idempotency[redis]'
+```
+
+```python
+import redis.asyncio
+
+from fastapi import FastAPI
+from fastapi_idempotency import IdempotencyMiddleware, RedisStore
+
+# Production-recommended client config — see RedisStore docstring for
+# the full rationale (connection-pool sizing, socket timeouts, etc).
+client = redis.asyncio.Redis(
+    connection_pool=redis.asyncio.BlockingConnectionPool(
+        max_connections=200,    # tune per RPS x p99 latency
+        timeout=2.0,            # bound queue wait on saturation
+    ),
+    socket_timeout=1.0,         # bound stalled-Redis cascades
+    socket_connect_timeout=1.0,
+)
+
+app = FastAPI()
+app.add_middleware(IdempotencyMiddleware, store=RedisStore(client))
+```
+
+Atomicity: `acquire` is a single Lua `EVAL`, so concurrent workers
+cannot double-claim a key. The client must be constructed with
+`decode_responses=False` (the default) — the codec operates on raw
+bytes and `decode_responses=True` would silently corrupt msgpack.
+TTL eviction uses Redis `PEXPIRE`; record fields are advisory metadata
+(query Redis `PTTL` for the eviction authority).
+
 ## How it works
 
 The middleware watches non-safe HTTP methods (POST/PATCH/PUT/DELETE) for

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -105,6 +105,56 @@ Body is.)
 - **Source IP**: same reasoning as headers — too volatile and not
   intent-bearing.
 
+## Time source for the Redis backend
+
+**Status: v0.2.0.**
+
+`RedisStore` mixes two clocks deliberately:
+
+- **TTL eviction** is server-side: `PEXPIRE` on the Redis key gives Redis
+  full control over when the record disappears. No Python clock involvement
+  in eviction means workers can't disagree on "is this slot still alive?"
+  during a brownout.
+- **Record fields** (`created_at`, `expires_at` inside
+  `IdempotencyRecord`) are computed in Python via `time.time()` before
+  encoding.
+
+### Why not use `redis.call('TIME')` for record fields too
+
+The Lua acquire script can read Redis server time via `TIME`, and an
+earlier draft of v0.2.0 planned to inject server timestamps into every
+new record. The implementation revealed the cost: for Lua to set
+`created_at`/`expires_at` _inside_ the msgpack-encoded record, one of:
+
+1. Re-encode the record server-side via `cmsgpack` — but Lua's msgpack
+   library and Python's `msgpack` library disagree on float encoding
+   (subnormal handling, NaN representation). Cross-language drift would
+   break round-trip determinism (which we lock down via a test in
+   `_serde.py`).
+2. Store timestamps as separate Hash fields outside the msgpack blob,
+   and splice them into the decoded record Python-side. Significant
+   `_serde.py` changes for a marginal benefit.
+
+The benefit at issue: clock drift between workers. On NTP-synced hosts
+the drift is milliseconds; v0.2.0's smallest TTL default is 30 s
+(in-flight), 24 h (completed). A ms-scale skew on a 30 s TTL is 0.03 %.
+
+**Trade-off accepted**: Python-clock `created_at`/`expires_at` with
+documented NTP-sync requirement, in exchange for keeping `_serde.py` and
+the Lua script simple. The Redis-side `PEXPIRE` is the real eviction
+authority — record fields are advisory metadata for the application
+layer, not the source of truth for "is this expired".
+
+### Operational notes
+
+- **TTL metrics**: operators monitoring "time-to-eviction" should query
+  Redis `PTTL` directly, not compute `record.expires_at - time.time()`.
+  The record fields can drift on NTP step adjustments and would page on
+  spurious negative values.
+- **Cluster routing**: the acquire Lua script touches a single key
+  (`{namespace}:{key}`), so it is safe under Redis Cluster routing —
+  no cross-slot operations.
+
 ## Streaming response pass-through
 
 _To be written during v0.2.0._

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
     "test_stores_redis",
+    "test_stores_redis_concurrent",
     "test_stores_redis_integration",
     "conftest",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,22 @@ enable_error_code = ["redundant-expr", "truthy-bool", "possibly-undefined"]
 module = ["msgpack.*", "testcontainers.*"]
 ignore_missing_imports = true
 
+# redis-py 5.x async-client typing returns `Awaitable[T] | T` unions that
+# mypy can't narrow on `await`. Suppress at the test-module level instead
+# of per-call `# type: ignore[misc]`.
+#
+# Module names are bare (no `tests.` prefix) because `tests/` has no
+# `__init__.py` — mypy sees each test file as a top-level module. If
+# anyone adds `tests/__init__.py`, prepend `tests.` to each entry below
+# or the override silently stops matching and `[misc]` re-fires.
+[[tool.mypy.overrides]]
+module = [
+    "test_stores_redis",
+    "test_stores_redis_integration",
+    "conftest",
+]
+disable_error_code = ["misc"]
+
 [tool.pytest.ini_options]
 minversion = "8.0"
 addopts = "-ra --strict-markers --strict-config"

--- a/src/fastapi_idempotency/__init__.py
+++ b/src/fastapi_idempotency/__init__.py
@@ -1,8 +1,9 @@
 """fastapi-idempotency: ``Idempotency-Key`` middleware for FastAPI / Starlette.
 
 Public API (the names listed in ``__all__``) is what most users need:
-the middleware, the in-memory store, the ``Store`` Protocol for custom
-backends, and the exception hierarchy for catch blocks.
+the middleware, the in-memory store, ``RedisStore`` (requires the
+``[redis]`` extra), the ``Store`` Protocol for custom backends, and
+the exception hierarchy for catch blocks.
 
 Store-implementation details (``AcquireOutcome``, ``AcquireResult``,
 ``IdempotencyRecord``, ``IdempotencyState``, ``CachedResponse``,
@@ -10,9 +11,17 @@ Store-implementation details (``AcquireOutcome``, ``AcquireResult``,
 module for users writing custom ``Store`` implementations, but are kept
 out of ``__all__`` to signal that they are advanced surface — not what
 a typical caller reaches for.
+
+``RedisStore`` is loaded lazily via :pep:`562` ``__getattr__`` so that
+``import fastapi_idempotency`` keeps working without the ``[redis]``
+extra installed — accessing ``fastapi_idempotency.RedisStore`` is what
+triggers the import (and the helpful ``ImportError`` from
+``stores.redis`` if the extra is missing).
 """
 
 from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from .errors import (
     ConflictError,
@@ -34,6 +43,12 @@ from .types import (
     IdempotencyState as IdempotencyState,
 )
 
+if TYPE_CHECKING:
+    # Static-checker re-export so ``from fastapi_idempotency import RedisStore``
+    # type-checks without forcing an import at module load (which would fail
+    # for users who installed the package without the ``[redis]`` extra).
+    from .stores.redis import RedisStore as RedisStore
+
 __version__ = "0.1.0"
 
 __all__ = [
@@ -42,8 +57,28 @@ __all__ = [
     "IdempotencyError",
     "IdempotencyMiddleware",
     "InMemoryStore",
+    "RedisStore",
     "RequestTooLargeError",
     "Store",
     "StoreError",
     "__version__",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """PEP 562 lazy attribute access.
+
+    Defers importing ``RedisStore`` (and the optional ``redis`` extra
+    it depends on) until the user actually references it. Without this,
+    ``import fastapi_idempotency`` would fail on installations that
+    lack the ``[redis]`` extra — even for users who only use
+    ``InMemoryStore``.
+    """
+    if name == "RedisStore":
+        # Lazy import is the whole point: deferring redis-py until access
+        # lets users without the [redis] extra still `import fastapi_idempotency`.
+        from .stores.redis import RedisStore  # noqa: PLC0415
+
+        return RedisStore
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/src/fastapi_idempotency/store.py
+++ b/src/fastapi_idempotency/store.py
@@ -78,13 +78,16 @@ class Store(Protocol):
 
         Preserves ``key``, ``fingerprint``, and ``created_at`` from the
         in-flight record; overwrites ``state``, ``expires_at``, and
-        ``response``.
+        ``response``. The new ``expires_at`` is ``now + ttl`` (this
+        ``ttl`` *replaces* any remaining acquire-phase TTL — eviction
+        is reseated, not extended).
 
         The caller must own the slot (i.e. previously received
         ``CREATED`` from ``acquire``). If no record exists for ``key``
-        — typically because the in-flight TTL elapsed before the handler
-        finished — the store raises :class:`StoreError`. Tune
-        ``in_flight_ttl`` upward if this fires in production.
+        — or the existing record has expired — the store raises
+        :class:`StoreError`. This typically means the in-flight TTL
+        elapsed before the handler finished; tune ``in_flight_ttl``
+        upward if this fires in production.
         """
         ...
 

--- a/src/fastapi_idempotency/stores/_serde.py
+++ b/src/fastapi_idempotency/stores/_serde.py
@@ -1,0 +1,277 @@
+"""Serialization/deserialization helpers for store-persisted records.
+
+Records are serialized as msgpack-encoded envelopes with an explicit schema
+version, so the on-disk shape can evolve in future minor releases without
+breaking already-stored records. Read paths verify the envelope version,
+validate field types/ranges defensively, and raise :class:`StoreError` on
+any malformed input.
+
+Wire format::
+
+    {
+        "v": 1,                          # schema version
+        "data": { ... record fields ... }
+    }
+
+This module is private (underscore-prefixed) — its API is an implementation
+detail of the store backends, not part of the public package surface.
+
+Logging note: error paths populate ``logger.debug(..., extra={...})`` with
+``version`` and ``expected`` fields so structured loggers (Datadog, Loki,
+ELK with JSON formatters) can grep deploy-incident logs in seconds. The
+fallback message string also embeds the values for plain-formatter logs.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+import msgpack
+
+from fastapi_idempotency.errors import StoreError
+from fastapi_idempotency.types import (
+    CachedResponse,
+    Fingerprint,
+    IdempotencyKey,
+    IdempotencyRecord,
+    IdempotencyState,
+)
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+# TODO(v=2): introduce MIN_SUPPORTED_VERSION when adding a new schema version,
+# and switch to a decoder registry (`_DECODERS = {1: _v1, 2: _v2}`) so old
+# records remain readable during rolling deploys.
+
+# Unpack limits — sized to the v0.3.0 production max_body_bytes default
+# (1 MiB) plus envelope overhead and headroom. These caps prevent
+# memory-DoS via attacker-crafted oversized payloads.
+_MAX_BODY_BYTES = 1 * 1024 * 1024  # 1 MiB
+_MAX_BUFFER_SIZE = 2 * _MAX_BODY_BYTES  # body + envelope + headroom
+_MAX_BIN_LEN = _MAX_BODY_BYTES
+_MAX_STR_LEN = 8 * 1024  # 8 KiB — header values realistic limit
+_MAX_ARRAY_LEN = 256  # max headers + safety margin
+_MAX_MAP_LEN = 16  # envelope + record fields
+_MAX_HEADERS = 100
+
+# HTTP status code valid range (inclusive lower, exclusive upper).
+_VALID_STATUS_RANGE = (100, 600)
+
+# Each header is a (name, value) pair — exactly 2 elements.
+_HEADER_PAIR_LEN = 2
+
+# Truncation length for exception repr in error messages — defends
+# against log-volume DoS via attacker-crafted multi-MB blob whose repr
+# would otherwise blow up log lines.
+_EXC_REPR_LIMIT = 200
+
+
+def encode_record(record: IdempotencyRecord) -> bytes:
+    """Serialize an :class:`IdempotencyRecord` to versioned msgpack bytes.
+
+    The resulting bytes are deterministic across calls (same input → same
+    bytes); see ``test_encode_is_deterministic`` for the pinned contract.
+    """
+    envelope = {
+        "v": SCHEMA_VERSION,
+        "data": _record_to_dict(record),
+    }
+    return msgpack.packb(envelope, use_bin_type=True)  # type: ignore[no-any-return]
+
+
+def decode_record(data: bytes) -> IdempotencyRecord:
+    """Deserialize msgpack bytes (as written by :func:`encode_record`).
+
+    Raises :class:`StoreError` on:
+      * malformed msgpack bytes,
+      * input bytes exceeding the configured buffer size,
+      * envelope shape violations,
+      * unknown schema version,
+      * any field validation failure (wrong type, out-of-range, missing).
+    """
+    if len(data) > _MAX_BUFFER_SIZE:
+        msg = f"record bytes ({len(data)}) exceed buffer size limit ({_MAX_BUFFER_SIZE})"
+        raise StoreError(msg)
+
+    try:
+        envelope = msgpack.unpackb(
+            data,
+            raw=False,
+            strict_map_key=True,
+            max_bin_len=_MAX_BIN_LEN,
+            max_str_len=_MAX_STR_LEN,
+            max_array_len=_MAX_ARRAY_LEN,
+            max_map_len=_MAX_MAP_LEN,
+        )
+    except (msgpack.exceptions.UnpackException, ValueError, TypeError) as exc:
+        msg = f"malformed record bytes: {repr(exc)[:_EXC_REPR_LIMIT]}"
+        raise StoreError(msg) from exc
+
+    if not isinstance(envelope, dict):
+        msg = f"record envelope is not a dict: {type(envelope).__name__}"
+        raise StoreError(msg)
+
+    version = envelope.get("v")
+    if version != SCHEMA_VERSION:
+        msg = (
+            f"unsupported record schema version {version!r}; "
+            f"this build understands {SCHEMA_VERSION}"
+        )
+        logger.debug(
+            "_serde: rejecting unsupported version",
+            extra={"version": version, "expected": SCHEMA_VERSION},
+        )
+        raise StoreError(msg)
+
+    data_dict = envelope.get("data")
+    if not isinstance(data_dict, dict):
+        msg = "record envelope missing 'data' dict"
+        raise StoreError(msg)
+
+    try:
+        return _dict_to_record(data_dict)
+    except (KeyError, ValueError, TypeError) as exc:
+        msg = f"invalid record fields: {repr(exc)[:_EXC_REPR_LIMIT]}"
+        raise StoreError(msg) from exc
+
+
+def _record_to_dict(record: IdempotencyRecord) -> dict[str, Any]:
+    return {
+        "key": str(record.key),
+        "fingerprint": str(record.fingerprint),
+        "state": record.state.value,
+        "created_at": record.created_at,
+        "expires_at": record.expires_at,
+        "response": (_response_to_dict(record.response) if record.response is not None else None),
+    }
+
+
+def _dict_to_record(d: dict[str, Any]) -> IdempotencyRecord:
+    """Construct ``IdempotencyRecord`` from decoded dict.
+
+    Raises ``KeyError`` on missing fields, ``ValueError`` on invalid values,
+    ``TypeError`` on wrong types — all wrapped into ``StoreError`` by the
+    caller (:func:`decode_record`).
+    """
+    # NewType is a no-op at runtime — we validate each field explicitly to
+    # catch type-confusion attacks (e.g., key as int, body as str).
+
+    key_value = d["key"]
+    if not isinstance(key_value, str):
+        msg = f"key must be str, got {type(key_value).__name__}"
+        raise TypeError(msg)
+
+    fingerprint_value = d["fingerprint"]
+    if not isinstance(fingerprint_value, str):
+        msg = f"fingerprint must be str, got {type(fingerprint_value).__name__}"
+        raise TypeError(msg)
+
+    state_value = d["state"]  # KeyError if missing → wrapped by caller
+    state = IdempotencyState(state_value)  # ValueError if unknown → wrapped
+
+    created_at = d["created_at"]
+    if not isinstance(created_at, (int, float)) or not math.isfinite(created_at):
+        msg = f"created_at must be finite number, got {created_at!r}"
+        raise TypeError(msg)
+
+    expires_at = d["expires_at"]
+    if not isinstance(expires_at, (int, float)) or not math.isfinite(expires_at):
+        msg = f"expires_at must be finite number, got {expires_at!r}"
+        raise TypeError(msg)
+
+    response_dict = d.get("response")
+    response = _dict_to_response(response_dict) if response_dict is not None else None
+
+    return IdempotencyRecord(
+        key=IdempotencyKey(key_value),
+        fingerprint=Fingerprint(fingerprint_value),
+        state=state,
+        created_at=float(created_at),
+        expires_at=float(expires_at),
+        response=response,
+    )
+
+
+def _response_to_dict(response: CachedResponse) -> dict[str, Any]:
+    return {
+        "status_code": response.status_code,
+        "headers": [list(pair) for pair in response.headers],
+        "body": response.body,
+        "media_type": response.media_type,
+    }
+
+
+def _dict_to_response(d: dict[str, Any]) -> CachedResponse:
+    """Construct ``CachedResponse`` from decoded dict.
+
+    See :func:`_coerce_header_pairs` for the structural validation of
+    headers (arity + bytes-type — guards against ``bytes(int)``
+    memory-blow-up attacks).
+    """
+    status_code = d["status_code"]
+    if not isinstance(status_code, int) or isinstance(status_code, bool):
+        # bool is subclass of int — explicit reject
+        msg = f"status_code must be int, got {type(status_code).__name__}"
+        raise TypeError(msg)
+    if not (_VALID_STATUS_RANGE[0] <= status_code < _VALID_STATUS_RANGE[1]):
+        msg = f"status_code {status_code} outside HTTP status range"
+        raise ValueError(msg)
+
+    body = d["body"]
+    if not isinstance(body, (bytes, bytearray)):
+        msg = f"body must be bytes, got {type(body).__name__}"
+        raise TypeError(msg)
+
+    headers_raw = d["headers"]
+    if not isinstance(headers_raw, list):
+        msg = f"headers must be list, got {type(headers_raw).__name__}"
+        raise TypeError(msg)
+    if len(headers_raw) > _MAX_HEADERS:
+        msg = f"headers count {len(headers_raw)} exceeds {_MAX_HEADERS}"
+        raise ValueError(msg)
+    headers = _coerce_header_pairs(headers_raw)
+
+    media_type = d["media_type"]
+    if media_type is not None and not isinstance(media_type, str):
+        msg = f"media_type must be str or None, got {type(media_type).__name__}"
+        raise TypeError(msg)
+
+    return CachedResponse(
+        status_code=status_code,
+        headers=headers,
+        body=bytes(body),  # bytearray → bytes for immutability
+        media_type=media_type,
+    )
+
+
+def _coerce_header_pairs(
+    raw: list[Any],
+) -> tuple[tuple[bytes, bytes], ...]:
+    """Validate and coerce a list of header pairs.
+
+    Each pair must be a 2-element list/tuple of bytes. Guards against:
+      * arity confusion (3-tuple sneaking through into iteration unpack);
+      * ``bytes(int)`` memory-blow-up — if a decoded value is an int,
+        ``bytes(N)`` allocates N null bytes, so a stored value of
+        ``2**30`` blows up to 1 GiB before any sanity check.
+    """
+    result: list[tuple[bytes, bytes]] = []
+    for pair in raw:
+        if not isinstance(pair, (list, tuple)):
+            msg = f"header pair must be list/tuple, got {type(pair).__name__}"
+            raise TypeError(msg)
+        if len(pair) != _HEADER_PAIR_LEN:
+            msg = f"header pair must have {_HEADER_PAIR_LEN} elements, got {len(pair)}"
+            raise ValueError(msg)
+        name, value = pair
+        if not isinstance(name, (bytes, bytearray)):
+            msg = f"header name must be bytes, got {type(name).__name__}"
+            raise TypeError(msg)
+        if not isinstance(value, (bytes, bytearray)):
+            msg = f"header value must be bytes, got {type(value).__name__}"
+            raise TypeError(msg)
+        result.append((bytes(name), bytes(value)))
+    return tuple(result)

--- a/src/fastapi_idempotency/stores/memory.py
+++ b/src/fastapi_idempotency/stores/memory.py
@@ -77,15 +77,25 @@ class InMemoryStore:
         ttl: float,
     ) -> None:
         async with self._lock:
+            now = time.time()
             existing = self._records.get(key)
-            if existing is None:
+            # Treat expired-but-not-yet-purged records as gone — keeps
+            # InMemory in line with Redis (PEXPIRE evicts and the Lua
+            # complete script's EXISTS check raises). Without this guard
+            # InMemory silently overwrites an expired in-flight slot
+            # with a fresh COMPLETED record, masking the in_flight_ttl
+            # tuning bug operators are supposed to see.
+            #
+            # Must run inside ``self._lock`` — moving this check outside
+            # the critical section reintroduces a TOCTOU silent-overwrite.
+            if existing is None or existing.is_expired(now):
                 raise StoreError(
                     f"cannot complete unknown idempotency key: {key!r}",
                 )
             self._records[key] = replace(
                 existing,
                 state=IdempotencyState.COMPLETED,
-                expires_at=time.time() + ttl,
+                expires_at=now + ttl,
                 response=response,
             )
 

--- a/src/fastapi_idempotency/stores/redis.py
+++ b/src/fastapi_idempotency/stores/redis.py
@@ -52,7 +52,9 @@ exhausts the default 50-connection pool and surfaces as raw
 
 from __future__ import annotations
 
+import logging
 import time
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 try:
@@ -79,6 +81,22 @@ from fastapi_idempotency.types import (
 
 if TYPE_CHECKING:
     from redis.asyncio import Redis
+
+
+logger = logging.getLogger(__name__)
+
+
+def _wrap_redis_error(op: str, exc: BaseException) -> StoreError:
+    """Wrap a redis-py exception as :class:`StoreError`.
+
+    Logs at DEBUG so operators flipping to debug level get a breadcrumb
+    before the StoreError bubbles up to the middleware. Truncated repr
+    defends against log-volume DoS via attacker-crafted multi-MB exception
+    text.
+    """
+    logger.debug("redis %s failed: %r", op, exc)
+    msg = f"Redis {op} failed: {repr(exc)[:200]}"
+    return StoreError(msg)
 
 
 # Atomic acquire as a single Lua call — classifies into one of four
@@ -125,6 +143,32 @@ return {'replay', existing_data}
 """
 
 
+# Atomic complete: validates the slot still exists (TTL race may have
+# evicted it between Python's read and this script), then writes the new
+# state + data and refreshes TTL to ``completed_ttl``. Returns 'ok' on
+# success, ``redis.error_reply`` if the slot is gone.
+#
+#   KEYS: [1] full namespaced key
+#   ARGV: [1] new-record msgpack bytes, [2] ttl_ms (positive int)
+_COMPLETE_LUA = """
+local key = KEYS[1]
+local data = ARGV[1]
+local ttl_ms = tonumber(ARGV[2])
+
+if not ttl_ms or ttl_ms <= 0 then
+  return redis.error_reply('ttl_ms must be a positive integer')
+end
+
+if redis.call('EXISTS', key) == 0 then
+  return redis.error_reply('cannot complete unknown idempotency key')
+end
+
+redis.call('HSET', key, 'state', 'completed', 'data', data)
+redis.call('PEXPIRE', key, ttl_ms)
+return 'ok'
+"""
+
+
 class RedisStore:  # pragma: no cover
     """Distributed store backed by Redis.
 
@@ -154,6 +198,7 @@ class RedisStore:  # pragma: no cover
         self.client = client
         self.namespace = namespace
         self._acquire_script: Any = client.register_script(_ACQUIRE_LUA)
+        self._complete_script: Any = client.register_script(_COMPLETE_LUA)
 
     async def acquire(
         self,
@@ -184,8 +229,7 @@ class RedisStore:  # pragma: no cover
                 args=[str(fingerprint), ttl_ms, new_data],
             )
         except (RedisError, OSError) as exc:
-            msg = f"Redis acquire failed: {repr(exc)[:200]}"
-            raise StoreError(msg) from exc
+            raise _wrap_redis_error("acquire", exc) from exc
 
         outcome_raw, record_bytes = result
         outcome_value = (
@@ -199,7 +243,24 @@ class RedisStore:  # pragma: no cover
         return AcquireResult(outcome=outcome, record=record)
 
     async def get(self, key: IdempotencyKey) -> IdempotencyRecord | None:
-        raise NotImplementedError
+        full_key = self._key(key)
+        try:
+            # redis-py 5.x async-client typing is imprecise; runtime is awaitable.
+            data = await self.client.hget(full_key, "data")  # type: ignore[misc]
+        except (RedisError, OSError) as exc:
+            raise _wrap_redis_error("get", exc) from exc
+
+        if data is None:
+            return None
+
+        record = decode_record(data)
+        # Symmetry with InMemoryStore: filter expired records Python-side.
+        # Defense in depth — Redis PEXPIRE is the primary eviction path,
+        # but a millisecond-scale race between expiry and our read can
+        # surface a record that is already expired by client-side clock.
+        if record.is_expired(time.time()):
+            return None
+        return record
 
     async def complete(
         self,
@@ -207,10 +268,48 @@ class RedisStore:  # pragma: no cover
         response: CachedResponse,
         ttl: float,
     ) -> None:
-        raise NotImplementedError
+        # NOTE: this is a 2-RTT operation (HGET + Lua). Between the read and
+        # the script call, a TTL eviction + re-acquire could create a fresh
+        # slot at the same key — we'd then complete-overwrite that fresh
+        # slot's data. Matches InMemoryStore behavior (caller-owns-slot
+        # contract; race bounded by in_flight_ttl tuning). Tracked for both
+        # backends in a v0.3.0+ hardening pass.
+        full_key = self._key(key)
+
+        # Read existing to preserve identity (key, fingerprint, created_at).
+        try:
+            existing_data = await self.client.hget(full_key, "data")  # type: ignore[misc]
+        except (RedisError, OSError) as exc:
+            raise _wrap_redis_error("complete", exc) from exc
+
+        if existing_data is None:
+            msg = f"cannot complete unknown idempotency key: {key!r}"
+            raise StoreError(msg)
+
+        existing = decode_record(existing_data)
+        new_record = replace(
+            existing,
+            state=IdempotencyState.COMPLETED,
+            expires_at=time.time() + ttl,
+            response=response,
+        )
+        new_data = encode_record(new_record)
+
+        ttl_ms = int(ttl * 1000)
+        try:
+            await self._complete_script(
+                keys=[full_key],
+                args=[new_data, ttl_ms],
+            )
+        except (RedisError, OSError) as exc:
+            raise _wrap_redis_error("complete", exc) from exc
 
     async def release(self, key: IdempotencyKey) -> None:
-        raise NotImplementedError
+        full_key = self._key(key)
+        try:
+            await self.client.delete(full_key)
+        except (RedisError, OSError) as exc:
+            raise _wrap_redis_error("release", exc) from exc
 
     def _key(self, key: IdempotencyKey) -> str:
         return f"{self.namespace}:{key}"

--- a/src/fastapi_idempotency/stores/redis.py
+++ b/src/fastapi_idempotency/stores/redis.py
@@ -169,7 +169,7 @@ return 'ok'
 """
 
 
-class RedisStore:  # pragma: no cover
+class RedisStore:
     """Distributed store backed by Redis.
 
     Atomic ``acquire`` is implemented as a single Lua ``EVAL`` so concurrent
@@ -177,14 +177,6 @@ class RedisStore:  # pragma: no cover
     are straightforward HSET/HGET/DEL paths — only ``acquire`` needs Lua.
 
     Structurally conforms to :class:`fastapi_idempotency.store.Store`.
-
-    .. note::
-        ``# pragma: no cover`` stays on until slice 8 wires a redis job
-        into CI. The cross-store conformance suite (slice 5) and
-        concurrency/TTL slices (6, 7) exercise this class against a
-        testcontainers Redis locally, but CI runs
-        ``pytest --cov -m "not redis"`` until the redis job lands —
-        without the pragma, the 95% coverage gate would block merges.
     """
 
     def __init__(self, client: Redis, *, namespace: str = "idem") -> None:
@@ -288,10 +280,19 @@ class RedisStore:  # pragma: no cover
             raise StoreError(msg)
 
         existing = decode_record(existing_data)
+        # Defense in depth, symmetric with ``get``: PEXPIRE may not have
+        # fired yet on a sub-millisecond race, but the Python clock can
+        # already see ``expires_at`` elapsed. Treat that as gone (matches
+        # InMemoryStore's complete-on-expired guard from issue #17 / slice 7).
+        now = time.time()
+        if existing.is_expired(now):
+            msg = f"cannot complete unknown idempotency key: {key!r}"
+            raise StoreError(msg)
+
         new_record = replace(
             existing,
             state=IdempotencyState.COMPLETED,
-            expires_at=time.time() + ttl,
+            expires_at=now + ttl,
             response=response,
         )
         new_data = encode_record(new_record)

--- a/src/fastapi_idempotency/stores/redis.py
+++ b/src/fastapi_idempotency/stores/redis.py
@@ -3,43 +3,157 @@
 Requires the ``redis`` extra::
 
     pip install fastapi-idempotency[redis]
+
+Storage layout: one HASH per idempotency key at ``{namespace}:{key}`` with
+fields ``fp`` (fingerprint hex string), ``state`` (enum value string), and
+``data`` (msgpack-encoded :class:`IdempotencyRecord`). The Lua acquire
+script reads ``fp`` and ``state`` directly without parsing msgpack,
+keeping the server-side critical section minimal. ``HMGET`` reads all
+three fields in one atomic snapshot, eliminating eviction-race holes
+between sequential ``HGET``\\s.
+
+TTL is set via ``PEXPIRE`` on the key; Redis handles eviction. See
+``docs/DESIGN.md`` ("Time source for the Redis backend") for why
+``created_at``/``expires_at`` inside the record are Python-clock while
+TTL is Redis-clock.
+
+Operators monitoring TTL should query Redis ``PTTL`` directly rather
+than computing ``record.expires_at - time.time()`` — record fields are
+advisory metadata, not the eviction authority.
+
+The Lua script touches a single key, so it is safe under Redis Cluster
+routing (no cross-slot operations). ``register_script`` caches the
+script SHA1 locally; ``redis-py`` re-issues ``EVAL`` automatically on
+``NOSCRIPT`` (e.g. after ``SCRIPT FLUSH`` or replica failover).
+
+The caller owns the :class:`redis.asyncio.Redis` client lifecycle — we
+do not close it. The client must be constructed with
+``decode_responses=False`` (the default); the codec operates on raw
+bytes and a ``decode_responses=True`` client will silently corrupt
+msgpack payloads.
+
+Recommended production client configuration::
+
+    import redis.asyncio
+    client = redis.asyncio.Redis(
+        connection_pool=redis.asyncio.BlockingConnectionPool(
+            max_connections=200,    # tune per RPS x p99 latency
+            timeout=2.0,            # bound queue wait on saturation
+        ),
+        socket_timeout=1.0,         # bound stalled-Redis cascades
+        socket_connect_timeout=1.0,
+    )
+
+Without ``socket_timeout`` an unhealthy Redis blocks ``acquire``
+indefinitely; without ``BlockingConnectionPool`` a stalled Redis
+exhausts the default 50-connection pool and surfaces as raw
+``ConnectionError``.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import time
+from typing import TYPE_CHECKING, Any
 
+try:
+    import redis.asyncio  # noqa: F401
+    from redis.exceptions import RedisError
+except ImportError as exc:  # pragma: no cover
+    msg = (
+        "RedisStore requires the 'redis' extra. "
+        "Install with: pip install fastapi-idempotency[redis]"
+    )
+    raise ImportError(msg) from exc
+
+from fastapi_idempotency.errors import StoreError
+from fastapi_idempotency.stores._serde import decode_record, encode_record
 from fastapi_idempotency.types import (
+    AcquireOutcome,
     AcquireResult,
     CachedResponse,
     Fingerprint,
     IdempotencyKey,
     IdempotencyRecord,
+    IdempotencyState,
 )
 
 if TYPE_CHECKING:
     from redis.asyncio import Redis
 
 
+# Atomic acquire as a single Lua call — classifies into one of four
+# AcquireOutcome branches in one round-trip. Returns a 2-element table:
+# the outcome value (matches AcquireOutcome.<m>.value strings) and the
+# record's msgpack bytes (newly inserted or existing, depending on branch).
+#
+# HMGET reads all three fields in one atomic snapshot — closes the
+# eviction-race window where sequential HGETs could see a partially
+# evicted key (state=False, falling through to REPLAY with garbage data).
+#
+#   KEYS: [1] full namespaced key
+#   ARGV: [1] fingerprint hex, [2] ttl_ms (positive int), [3] new-record msgpack bytes
+_ACQUIRE_LUA = """
+local key = KEYS[1]
+local fp = ARGV[1]
+local ttl_ms = tonumber(ARGV[2])
+local data = ARGV[3]
+
+if not ttl_ms or ttl_ms <= 0 then
+  return redis.error_reply('ttl_ms must be a positive integer')
+end
+
+local existing = redis.call('HMGET', key, 'fp', 'state', 'data')
+local existing_fp = existing[1]
+local existing_state = existing[2]
+local existing_data = existing[3]
+
+if not existing_fp then
+  redis.call('HSET', key, 'fp', fp, 'state', 'in_flight', 'data', data)
+  redis.call('PEXPIRE', key, ttl_ms)
+  return {'created', data}
+end
+
+if existing_fp ~= fp then
+  return {'mismatch', existing_data}
+end
+
+if existing_state == 'in_flight' then
+  return {'in_flight', existing_data}
+end
+
+return {'replay', existing_data}
+"""
+
+
 class RedisStore:  # pragma: no cover
     """Distributed store backed by Redis.
 
-    Atomicity of :meth:`acquire` and :meth:`complete` is implemented with
-    ``SET NX`` plus a small Lua script (``EVAL``) so concurrent workers
-    cannot race on the same key.
+    Atomic ``acquire`` is implemented as a single Lua ``EVAL`` so concurrent
+    workers cannot race on the same key. ``get`` / ``complete`` / ``release``
+    arrive in the next slice.
 
     Structurally conforms to :class:`fastapi_idempotency.store.Store`.
 
     .. note::
-        Stub in v0.1.0 — every method raises :class:`NotImplementedError`.
-        Real implementation lands in v0.2.0; ``# pragma: no cover`` on the
-        class lets v0.1.0 coverage stay honest. Remove the pragma when
-        the class becomes functional.
+        Implementation in progress (issue #17). Methods other than
+        ``acquire`` raise :class:`NotImplementedError` until the next
+        slice. ``# pragma: no cover`` stays on until the cross-store
+        conformance suite (slice 5) exercises this class against a real
+        Redis via testcontainers.
     """
 
     def __init__(self, client: Redis, *, namespace: str = "idem") -> None:
+        # redis-py's get_encoder() is untyped in stubs as of 5.x.
+        encoder = client.get_encoder()  # type: ignore[no-untyped-call]
+        if encoder.decode_responses:
+            msg = (
+                "RedisStore requires a client with decode_responses=False; "
+                "the codec operates on raw bytes."
+            )
+            raise ValueError(msg)
         self.client = client
         self.namespace = namespace
+        self._acquire_script: Any = client.register_script(_ACQUIRE_LUA)
 
     async def acquire(
         self,
@@ -47,7 +161,42 @@ class RedisStore:  # pragma: no cover
         fingerprint: Fingerprint,
         ttl: float,
     ) -> AcquireResult:
-        raise NotImplementedError
+        # Build the record we'd insert if CREATED. For other branches the
+        # Lua script returns the existing record's bytes and this serialized
+        # blob is discarded — accepted simplicity-tax for a single-script API.
+        now = time.time()
+        new_record = IdempotencyRecord(
+            key=key,
+            fingerprint=fingerprint,
+            state=IdempotencyState.IN_FLIGHT,
+            created_at=now,
+            expires_at=now + ttl,
+            response=None,
+        )
+        new_data = encode_record(new_record)
+
+        full_key = self._key(key)
+        ttl_ms = int(ttl * 1000)
+
+        try:
+            result = await self._acquire_script(
+                keys=[full_key],
+                args=[str(fingerprint), ttl_ms, new_data],
+            )
+        except (RedisError, OSError) as exc:
+            msg = f"Redis acquire failed: {repr(exc)[:200]}"
+            raise StoreError(msg) from exc
+
+        outcome_raw, record_bytes = result
+        outcome_value = (
+            outcome_raw.decode("ascii")
+            if isinstance(outcome_raw, (bytes, bytearray))
+            else outcome_raw
+        )
+        outcome = AcquireOutcome(outcome_value)
+        record = decode_record(record_bytes)
+
+        return AcquireResult(outcome=outcome, record=record)
 
     async def get(self, key: IdempotencyKey) -> IdempotencyRecord | None:
         raise NotImplementedError
@@ -62,3 +211,6 @@ class RedisStore:  # pragma: no cover
 
     async def release(self, key: IdempotencyKey) -> None:
         raise NotImplementedError
+
+    def _key(self, key: IdempotencyKey) -> str:
+        return f"{self.namespace}:{key}"

--- a/src/fastapi_idempotency/stores/redis.py
+++ b/src/fastapi_idempotency/stores/redis.py
@@ -174,16 +174,17 @@ class RedisStore:  # pragma: no cover
 
     Atomic ``acquire`` is implemented as a single Lua ``EVAL`` so concurrent
     workers cannot race on the same key. ``get`` / ``complete`` / ``release``
-    arrive in the next slice.
+    are straightforward HSET/HGET/DEL paths — only ``acquire`` needs Lua.
 
     Structurally conforms to :class:`fastapi_idempotency.store.Store`.
 
     .. note::
-        Implementation in progress (issue #17). Methods other than
-        ``acquire`` raise :class:`NotImplementedError` until the next
-        slice. ``# pragma: no cover`` stays on until the cross-store
-        conformance suite (slice 5) exercises this class against a real
-        Redis via testcontainers.
+        ``# pragma: no cover`` stays on until slice 8 wires a redis job
+        into CI. The cross-store conformance suite (slice 5) and
+        concurrency/TTL slices (6, 7) exercise this class against a
+        testcontainers Redis locally, but CI runs
+        ``pytest --cov -m "not redis"`` until the redis job lands —
+        without the pragma, the 95% coverage gate would block merges.
     """
 
     def __init__(self, client: Redis, *, namespace: str = "idem") -> None:

--- a/tests/_redis_helpers.py
+++ b/tests/_redis_helpers.py
@@ -1,0 +1,28 @@
+"""Shared redis-test helpers — single source of truth for client construction.
+
+Both ``conftest.py``'s ``redis_client`` fixture and the spawn-worker in
+``test_stores_redis_concurrent.py`` need to construct an async Redis
+client with the same DB-defaulting rule. Centralizing here means a
+future change (e.g. moving from DB 15 to a per-worker offset for
+xdist) updates one place — without it, the subprocess silently flushes
+a different DB than the parent and the cross-process test would pass
+trivially against an empty key space.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+import redis.asyncio
+
+
+def make_async_client(redis_url: str) -> redis.asyncio.Redis:
+    """Build an async Redis client; default DB to 15 if URL has no ``/<db>``.
+
+    See ``conftest.py`` module docstring for the destructive-default
+    rationale (FLUSHDB blast radius vs typical DB 0 usage).
+    """
+    db_in_url = bool(urlparse(redis_url).path.lstrip("/"))
+    if db_in_url:
+        return redis.asyncio.from_url(redis_url)
+    return redis.asyncio.from_url(redis_url, db=15)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,77 @@
+"""Shared pytest fixtures.
+
+Redis fixtures spin up a real Redis instance via ``testcontainers`` for
+tests marked ``@pytest.mark.redis``. The container is session-scoped
+(one Docker startup per pytest run); ``redis_client`` is function-scoped
+with a per-test ``FLUSHDB`` for isolation.
+
+If Docker is not available, ``redis_url`` skips dependent tests with a
+clear message rather than failing — local development without Docker is
+supported. In CI, set ``REDIS_TESTS_REQUIRED=1`` to convert the skip
+into a hard failure (slice 8 will export this in the redis job, so
+"Docker missing in CI" doesn't masquerade as a green build).
+
+Container leaks: ``container.stop()`` runs in a ``finally`` block, but
+SIGKILL/segfault can bypass it. Testcontainers' Ryuk sidecar reaps
+orphaned containers within ~10s as a backstop. Don't disable Ryuk in CI
+(``TESTCONTAINERS_RYUK_DISABLED`` should remain unset).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator, Iterator
+
+import pytest
+import redis.asyncio
+from testcontainers.redis import RedisContainer
+
+# Pin the Redis image — alpine is ~5x smaller (faster CI pulls), and a
+# version tag defends against ``latest`` drift. Patch-level images
+# (7.2.x, alpine base CVE rebuilds) still float; pin a digest if a
+# specific patch ever causes test divergence.
+_REDIS_IMAGE = "redis:7.2-alpine"
+
+
+@pytest.fixture(scope="session")
+def redis_url() -> Iterator[str]:
+    """Boot a Redis container once per pytest session.
+
+    Yields the container's URL as ``redis://host:port``.
+    """
+    container = RedisContainer(_REDIS_IMAGE)
+    try:
+        container.start()
+    except Exception as exc:
+        # Broad on purpose: docker absent, daemon down, image pull fail —
+        # all reduce to "skip these tests, run the rest".
+        if os.environ.get("REDIS_TESTS_REQUIRED") == "1":
+            pytest.fail(
+                f"REDIS_TESTS_REQUIRED=1 but Redis container failed to start: {exc!r}",
+            )
+        pytest.skip(
+            f"Docker not available ({exc!r}); to bypass redis tests "
+            f'locally, run `pytest -m "not redis"`',
+        )
+
+    try:
+        host = container.get_container_host_ip()
+        port = container.get_exposed_port(6379)
+        yield f"redis://{host}:{port}"
+    finally:
+        container.stop()
+
+
+@pytest.fixture
+async def redis_client(redis_url: str) -> AsyncIterator[redis.asyncio.Redis]:
+    """Async Redis client connected to the session-scoped container.
+
+    ``FLUSHDB`` before each test ensures isolation between tests sharing
+    the same container instance.
+    """
+    client = redis.asyncio.from_url(redis_url)
+    try:
+        await client.flushdb()
+        yield client
+    finally:
+        await client.aclose()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,22 @@ supported. In CI, set ``REDIS_TESTS_REQUIRED=1`` to convert the skip
 into a hard failure (slice 8 will export this in the redis job, so
 "Docker missing in CI" doesn't masquerade as a green build).
 
+Set ``REDIS_URL`` to bypass the testcontainer entirely and point at an
+already-running Redis (e.g. a CI service container, or a local
+host-network container on a host where Docker bridge networking is
+broken). When ``REDIS_URL`` is set, Docker availability is irrelevant —
+``redis_url`` yields the URL directly after a synchronous ``PING`` to
+fail fast on a wrong/unreachable URL (same skip/fail semantics as the
+container path; ``REDIS_TESTS_REQUIRED=1`` converts skip into fail).
+
+DESTRUCTIVE: every redis-marked test runs ``FLUSHDB`` against the
+selected database before the test body. Never point ``REDIS_URL`` at a
+Redis you care about. As a defensive default, ``redis_client`` switches
+to DB 15 when the URL has no ``/<db>`` component — most local Redis
+deployments use DB 0 for Celery brokers, RQ queues, or app caches, so
+DB 15 keeps the blast radius off the common path. Specify ``/<db>``
+explicitly in ``REDIS_URL`` to override.
+
 Container leaks: ``container.stop()`` runs in a ``finally`` block, but
 SIGKILL/segfault can bypass it. Testcontainers' Ryuk sidecar reaps
 orphaned containers within ~10s as a backstop. Don't disable Ryuk in CI
@@ -21,8 +37,10 @@ from __future__ import annotations
 
 import os
 from collections.abc import AsyncIterator, Iterator
+from urllib.parse import urlparse
 
 import pytest
+import redis
 import redis.asyncio
 from testcontainers.redis import RedisContainer
 
@@ -33,26 +51,46 @@ from testcontainers.redis import RedisContainer
 _REDIS_IMAGE = "redis:7.2-alpine"
 
 
+def _redis_unavailable(reason: str) -> None:
+    """Skip or fail per ``REDIS_TESTS_REQUIRED`` — shared by both URL paths."""
+    if os.environ.get("REDIS_TESTS_REQUIRED") == "1":
+        pytest.fail(f"REDIS_TESTS_REQUIRED=1 but {reason}")
+    pytest.skip(
+        f"{reason}; to bypass redis tests locally, run "
+        f'`pytest -m "not redis"` or set REDIS_URL to an already-running Redis.',
+    )
+
+
 @pytest.fixture(scope="session")
 def redis_url() -> Iterator[str]:
     """Boot a Redis container once per pytest session.
 
-    Yields the container's URL as ``redis://host:port``.
+    Yields the container's URL as ``redis://host:port``. If ``REDIS_URL``
+    is set in the environment, that URL is yielded directly (after a
+    synchronous PING) and no container is started — the caller owns
+    Redis lifecycle.
     """
+    external = os.environ.get("REDIS_URL")
+    if external:
+        # Symmetry with the container path: validate connectivity once
+        # at session start so a wrong URL surfaces as skip/fail per
+        # REDIS_TESTS_REQUIRED, not per-test connection errors deeper in.
+        try:
+            sync_client = redis.Redis.from_url(external, socket_timeout=2.0)
+            sync_client.ping()
+            sync_client.close()
+        except Exception as exc:
+            _redis_unavailable(f"REDIS_URL={external!r} unreachable: {exc!r}")
+        yield external
+        return
+
     container = RedisContainer(_REDIS_IMAGE)
     try:
         container.start()
     except Exception as exc:
         # Broad on purpose: docker absent, daemon down, image pull fail —
         # all reduce to "skip these tests, run the rest".
-        if os.environ.get("REDIS_TESTS_REQUIRED") == "1":
-            pytest.fail(
-                f"REDIS_TESTS_REQUIRED=1 but Redis container failed to start: {exc!r}",
-            )
-        pytest.skip(
-            f"Docker not available ({exc!r}); to bypass redis tests "
-            f'locally, run `pytest -m "not redis"`',
-        )
+        _redis_unavailable(f"Docker not available ({exc!r})")
 
     try:
         host = container.get_container_host_ip()
@@ -67,9 +105,14 @@ async def redis_client(redis_url: str) -> AsyncIterator[redis.asyncio.Redis]:
     """Async Redis client connected to the session-scoped container.
 
     ``FLUSHDB`` before each test ensures isolation between tests sharing
-    the same container instance.
+    the same container instance. If the URL has no ``/<db>`` component,
+    defaults to DB 15 — see the module docstring for the destructive-
+    default rationale.
     """
-    client = redis.asyncio.from_url(redis_url)
+    db_in_url = bool(urlparse(redis_url).path.lstrip("/"))
+    client = (
+        redis.asyncio.from_url(redis_url) if db_in_url else redis.asyncio.from_url(redis_url, db=15)
+    )
     try:
         await client.flushdb()
         yield client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,12 +37,16 @@ from __future__ import annotations
 
 import os
 from collections.abc import AsyncIterator, Iterator
-from urllib.parse import urlparse
+from typing import TYPE_CHECKING
 
 import pytest
 import redis
-import redis.asyncio
 from testcontainers.redis import RedisContainer
+
+from _redis_helpers import make_async_client
+
+if TYPE_CHECKING:
+    import redis.asyncio
 
 # Pin the Redis image — alpine is ~5x smaller (faster CI pulls), and a
 # version tag defends against ``latest`` drift. Patch-level images
@@ -105,14 +109,10 @@ async def redis_client(redis_url: str) -> AsyncIterator[redis.asyncio.Redis]:
     """Async Redis client connected to the session-scoped container.
 
     ``FLUSHDB`` before each test ensures isolation between tests sharing
-    the same container instance. If the URL has no ``/<db>`` component,
-    defaults to DB 15 — see the module docstring for the destructive-
-    default rationale.
+    the same container instance. The DB-15-default rule lives in
+    ``make_async_client`` so the cross-process worker stays in sync.
     """
-    db_in_url = bool(urlparse(redis_url).path.lstrip("/"))
-    client = (
-        redis.asyncio.from_url(redis_url) if db_in_url else redis.asyncio.from_url(redis_url, db=15)
-    )
+    client = make_async_client(redis_url)
     try:
         await client.flushdb()
         yield client

--- a/tests/test_stores_conformance.py
+++ b/tests/test_stores_conformance.py
@@ -1,0 +1,275 @@
+"""Cross-store conformance suite — protocol contract enforced for every backend.
+
+Each test runs once per parametrized backend: ``InMemoryStore`` always,
+``RedisStore`` when ``@pytest.mark.redis`` is enabled and Docker is
+available (gated by the session-scoped ``redis_url`` fixture in
+``conftest.py``). If a backend ever drifts from the :class:`Store`
+protocol, the entire suite catches it without test duplication.
+
+Slice 6 (concurrency: 10 coros → exactly one CREATED) and slice 7
+(TTL expiry under real time) build on this fixture. This slice covers
+acquire/get/complete/release classification, identity preservation,
+and state-machine edges (complete-after-release, acquire-after-release,
+double-release). Expired-record paths defer to slice 7 — InMemory's
+negative-TTL trick is rejected by ``RedisStore`` (the Lua acquire script
+rejects ``ttl_ms <= 0`` by design), so a real wait under a short positive
+TTL is the only portable approach.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from fastapi_idempotency import (
+    AcquireOutcome,
+    CachedResponse,
+    Fingerprint,
+    IdempotencyKey,
+    IdempotencyState,
+    InMemoryStore,
+    Store,
+    StoreError,
+)
+from fastapi_idempotency.stores.redis import RedisStore
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+KEY = IdempotencyKey("order-conformance")
+FP = Fingerprint("fp-abc")
+RESPONSE = CachedResponse(
+    status_code=201,
+    headers=(
+        (b"content-type", b"application/json"),
+        (b"x-trace-id", b"abc-123"),
+    ),
+    body=b'{"id": 42, "status": "ok"}',
+    media_type="application/json",
+)
+
+
+@pytest.fixture(
+    params=[
+        pytest.param("memory", id="memory"),
+        pytest.param("redis", id="redis", marks=pytest.mark.redis),
+    ],
+)
+def store(request: pytest.FixtureRequest) -> Iterator[Store]:
+    """Yield each Store backend in turn for parametrized conformance.
+
+    Sync (not async) by design: pytest-asyncio cannot resolve an async
+    fixture (``redis_client``) via ``getfixturevalue`` from inside
+    another async fixture (running event loop conflict). A sync
+    accessor lets pytest-asyncio resolve ``redis_client`` cleanly, and
+    constructing a ``Store`` requires no awaits.
+
+    The redis branch resolves ``redis_client`` lazily via
+    ``getfixturevalue`` so ``pytest -m "not redis"`` deselects the redis
+    parameter before the container would start — InMemory-only runs
+    don't pay the Docker startup cost.
+    """
+    if request.param == "memory":
+        yield InMemoryStore()
+        return
+
+    redis_client = request.getfixturevalue("redis_client")
+    yield RedisStore(redis_client)
+
+
+# ---------------------------------------------------------------------------
+# acquire — outcome classification
+# ---------------------------------------------------------------------------
+
+
+async def test_acquire_returns_created_on_first_call(store: Store) -> None:
+    result = await store.acquire(KEY, FP, ttl=30.0)
+
+    assert result.outcome is AcquireOutcome.CREATED
+    assert result.record.key == KEY
+    assert result.record.fingerprint == FP
+    assert result.record.state is IdempotencyState.IN_FLIGHT
+    assert result.record.response is None
+    assert result.record.expires_at > time.time()
+
+
+async def test_acquire_duplicate_same_fingerprint_returns_in_flight(store: Store) -> None:
+    await store.acquire(KEY, FP, ttl=30.0)
+
+    result = await store.acquire(KEY, FP, ttl=30.0)
+
+    assert result.outcome is AcquireOutcome.IN_FLIGHT
+    assert result.record.state is IdempotencyState.IN_FLIGHT
+    assert result.record.fingerprint == FP
+    # IN_FLIGHT is pre-complete: a backend that returned a stale completed
+    # record's response here would leak it to a 409-responder.
+    assert result.record.response is None
+
+
+async def test_acquire_different_fingerprint_returns_mismatch(store: Store) -> None:
+    await store.acquire(KEY, FP, ttl=30.0)
+
+    result = await store.acquire(KEY, Fingerprint("fp-xyz"), ttl=30.0)
+
+    assert result.outcome is AcquireOutcome.MISMATCH
+    assert result.record.fingerprint == FP
+    # MISMATCH must not overwrite the holder; the original slot stays put.
+    fetched = await store.get(KEY)
+    assert fetched is not None
+    assert fetched.fingerprint == FP
+
+
+async def test_acquire_mismatch_after_complete(store: Store) -> None:
+    """MISMATCH must supersede REPLAY — privacy boundary across fingerprints.
+
+    Protocol contract (store.py): fingerprint comparison happens inside
+    the atomic section. A backend that ordered ``state`` before ``fp``
+    would replay a cached response across users with different
+    fingerprints — a real cross-tenant leak. Cheap to test, important.
+    """
+    await store.acquire(KEY, FP, ttl=30.0)
+    await store.complete(KEY, RESPONSE, ttl=3600.0)
+
+    result = await store.acquire(KEY, Fingerprint("fp-xyz"), ttl=30.0)
+
+    assert result.outcome is AcquireOutcome.MISMATCH
+
+
+async def test_acquire_after_complete_returns_replay(store: Store) -> None:
+    await store.acquire(KEY, FP, ttl=30.0)
+    await store.complete(KEY, RESPONSE, ttl=3600.0)
+
+    result = await store.acquire(KEY, FP, ttl=30.0)
+
+    assert result.outcome is AcquireOutcome.REPLAY
+    assert result.record.state is IdempotencyState.COMPLETED
+    assert result.record.response == RESPONSE
+
+
+# ---------------------------------------------------------------------------
+# get
+# ---------------------------------------------------------------------------
+
+
+async def test_get_returns_none_for_unknown_key(store: Store) -> None:
+    assert await store.get(KEY) is None
+
+
+async def test_get_returns_record_for_known_key(store: Store) -> None:
+    acquired = await store.acquire(KEY, FP, ttl=30.0)
+
+    fetched = await store.get(KEY)
+
+    assert fetched == acquired.record
+
+
+# ---------------------------------------------------------------------------
+# complete
+# ---------------------------------------------------------------------------
+
+
+async def test_complete_transitions_state_with_response(store: Store) -> None:
+    await store.acquire(KEY, FP, ttl=30.0)
+
+    await store.complete(KEY, RESPONSE, ttl=3600.0)
+
+    record = await store.get(KEY)
+    assert record is not None
+    assert record.state is IdempotencyState.COMPLETED
+    assert record.response == RESPONSE
+
+
+async def test_complete_preserves_identity(store: Store) -> None:
+    """``key``, ``fingerprint``, and ``created_at`` survive the COMPLETED transition."""
+    acquired = await store.acquire(KEY, FP, ttl=30.0)
+    original = acquired.record
+
+    await store.complete(KEY, RESPONSE, ttl=3600.0)
+
+    record = await store.get(KEY)
+    assert record is not None
+    assert record.key == original.key
+    assert record.fingerprint == original.fingerprint
+    assert record.created_at == original.created_at
+
+
+async def test_complete_raises_on_unknown_key(store: Store) -> None:
+    with pytest.raises(StoreError):
+        await store.complete(KEY, RESPONSE, ttl=3600.0)
+
+
+# ---------------------------------------------------------------------------
+# release
+# ---------------------------------------------------------------------------
+
+
+async def test_release_removes_the_slot(store: Store) -> None:
+    await store.acquire(KEY, FP, ttl=30.0)
+
+    await store.release(KEY)
+
+    assert await store.get(KEY) is None
+
+
+async def test_release_on_missing_key_is_noop(store: Store) -> None:
+    await store.release(KEY)  # must not raise
+
+
+async def test_double_release_is_noop(store: Store) -> None:
+    """release is idempotent — middleware error path may double-release."""
+    await store.acquire(KEY, FP, ttl=30.0)
+
+    await store.release(KEY)
+    await store.release(KEY)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# state-machine edges — release/complete/acquire interactions
+# ---------------------------------------------------------------------------
+
+
+async def test_complete_after_release_raises(store: Store) -> None:
+    """release wipes the slot; subsequent complete has no record to update."""
+    await store.acquire(KEY, FP, ttl=30.0)
+    await store.release(KEY)
+
+    with pytest.raises(StoreError):
+        await store.complete(KEY, RESPONSE, ttl=3600.0)
+
+
+async def test_acquire_after_release_returns_created(store: Store) -> None:
+    """release frees the slot for a fresh acquire (different fingerprint OK)."""
+    await store.acquire(KEY, FP, ttl=30.0)
+    await store.release(KEY)
+
+    result = await store.acquire(KEY, Fingerprint("fp-different"), ttl=30.0)
+
+    assert result.outcome is AcquireOutcome.CREATED
+
+
+# ---------------------------------------------------------------------------
+# CachedResponse roundtrip — defends the encode/decode contract end-to-end
+# ---------------------------------------------------------------------------
+
+
+async def test_response_roundtrip_preserves_all_fields(store: Store) -> None:
+    """Every CachedResponse field survives the codec roundtrip via the store.
+
+    Explicit per-field checks defend against a surprise ``__eq__``
+    override on a future CachedResponse subclass — equality could pass
+    while a field silently regresses.
+    """
+    await store.acquire(KEY, FP, ttl=30.0)
+    await store.complete(KEY, RESPONSE, ttl=3600.0)
+
+    result = await store.acquire(KEY, FP, ttl=30.0)
+
+    assert result.outcome is AcquireOutcome.REPLAY
+    assert result.record.response is not None
+    assert result.record.response.status_code == 201
+    assert result.record.response.headers == RESPONSE.headers
+    assert result.record.response.body == RESPONSE.body
+    assert result.record.response.media_type == "application/json"

--- a/tests/test_stores_conformance.py
+++ b/tests/test_stores_conformance.py
@@ -6,14 +6,13 @@ available (gated by the session-scoped ``redis_url`` fixture in
 ``conftest.py``). If a backend ever drifts from the :class:`Store`
 protocol, the entire suite catches it without test duplication.
 
-Slice 6 (concurrency: 10 coros → exactly one CREATED) and slice 7
-(TTL expiry under real time) build on this fixture. This slice covers
-acquire/get/complete/release classification, identity preservation,
-and state-machine edges (complete-after-release, acquire-after-release,
-double-release). Expired-record paths defer to slice 7 — InMemory's
-negative-TTL trick is rejected by ``RedisStore`` (the Lua acquire script
-rejects ``ttl_ms <= 0`` by design), so a real wait under a short positive
-TTL is the only portable approach.
+Slice 6 added single-process concurrency. Slice 7 (this) adds TTL
+expiry tests under real ``asyncio.sleep`` — InMemory's negative-TTL
+trick is rejected by ``RedisStore`` (the Lua acquire script rejects
+``ttl_ms <= 0`` by design), so a real wait under a short positive TTL
+is the only portable way to exercise expiry across both backends.
+TTL tests carry ``@pytest.mark.slow`` so quick dev runs can deselect
+them with ``pytest -m "not slow"``.
 """
 
 from __future__ import annotations
@@ -279,6 +278,71 @@ async def test_concurrent_acquire_yields_exactly_one_created(store: Store) -> No
     outcomes = Counter(r.outcome for r in results)
     assert outcomes[AcquireOutcome.CREATED] == 1
     assert outcomes[AcquireOutcome.IN_FLIGHT] == n - 1
+
+
+# ---------------------------------------------------------------------------
+# TTL expiry — real-time wait, only portable approach across backends
+# ---------------------------------------------------------------------------
+
+# 0.5s TTL + 0.7s sleep gives 0.2s margin — safe against CI jitter and
+# asyncio.sleep granularity. Lower would be faster but flaky.
+_TTL_S = 0.5
+_TTL_WAIT_S = 0.7
+
+
+@pytest.mark.slow
+async def test_get_returns_none_after_ttl_expires(store: Store) -> None:
+    """``get`` filters expired records — InMemory by Python clock,
+    Redis by PEXPIRE plus a Python-side ``is_expired`` defense in depth."""
+    await store.acquire(KEY, FP, ttl=_TTL_S)
+    await asyncio.sleep(_TTL_WAIT_S)
+
+    assert await store.get(KEY) is None
+
+
+@pytest.mark.slow
+async def test_acquire_after_ttl_expires_creates_fresh_slot(store: Store) -> None:
+    """Expired slots are reclaimed by the next ``acquire`` (lazy GC).
+
+    Closes the conformance gap from slice 5: the negative-TTL trick
+    (``ttl=-1.0``) is InMemory-only, so this expired-record reclaim
+    behavior couldn't be tested portably until a real wait was added.
+    """
+    await store.acquire(KEY, FP, ttl=_TTL_S)
+    await asyncio.sleep(_TTL_WAIT_S)
+
+    result = await store.acquire(KEY, FP, ttl=30.0)
+
+    assert result.outcome is AcquireOutcome.CREATED
+
+
+@pytest.mark.slow
+async def test_completed_record_expires_with_completed_ttl(store: Store) -> None:
+    """``complete``'s ``ttl`` argument actually drives expiry — separate
+    knob from ``acquire``'s in-flight ttl. Operators rely on this for
+    tuning replay-window length without touching in-flight semantics."""
+    await store.acquire(KEY, FP, ttl=30.0)
+    await store.complete(KEY, RESPONSE, ttl=_TTL_S)
+    await asyncio.sleep(_TTL_WAIT_S)
+
+    assert await store.get(KEY) is None
+
+
+@pytest.mark.slow
+async def test_complete_after_ttl_expires_raises(store: Store) -> None:
+    """Production race: in-flight TTL elapses before the handler finishes.
+
+    Both backends must raise — Redis via ``_COMPLETE_LUA``'s ``EXISTS``
+    check after PEXPIRE eviction, InMemory via the ``is_expired``
+    guard. Without this conformance test InMemory used to silently
+    overwrite the expired slot with a fresh COMPLETED record, hiding
+    the ``in_flight_ttl`` tuning bug operators are supposed to see.
+    """
+    await store.acquire(KEY, FP, ttl=_TTL_S)
+    await asyncio.sleep(_TTL_WAIT_S)
+
+    with pytest.raises(StoreError):
+        await store.complete(KEY, RESPONSE, ttl=3600.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_stores_conformance.py
+++ b/tests/test_stores_conformance.py
@@ -18,7 +18,9 @@ TTL is the only portable approach.
 
 from __future__ import annotations
 
+import asyncio
 import time
+from collections import Counter
 from typing import TYPE_CHECKING
 
 import pytest
@@ -248,6 +250,35 @@ async def test_acquire_after_release_returns_created(store: Store) -> None:
     result = await store.acquire(KEY, Fingerprint("fp-different"), ttl=30.0)
 
     assert result.outcome is AcquireOutcome.CREATED
+
+
+# ---------------------------------------------------------------------------
+# concurrency — single-process race
+# ---------------------------------------------------------------------------
+
+
+async def test_concurrent_acquire_yields_exactly_one_created(store: Store) -> None:
+    """Single-process race on one key — exactly one wins CREATED.
+
+    Tests two different mechanisms in one shape:
+
+    - InMemoryStore: ``asyncio.Lock`` serializes critical sections in
+      the single event loop.
+    - RedisStore: the Lua ``acquire`` script is atomic on the Redis
+      server side (Redis is single-threaded for command execution),
+      so even N coroutines sharing one connection pool can't double-claim.
+
+    Cross-process atomicity (the property that justifies RedisStore over
+    InMemoryStore) is covered by ``test_stores_redis_concurrent.py``.
+    """
+    n = 10
+    results = await asyncio.gather(
+        *(store.acquire(KEY, FP, ttl=30.0) for _ in range(n)),
+    )
+
+    outcomes = Counter(r.outcome for r in results)
+    assert outcomes[AcquireOutcome.CREATED] == 1
+    assert outcomes[AcquireOutcome.IN_FLIGHT] == n - 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_stores_memory.py
+++ b/tests/test_stores_memory.py
@@ -1,21 +1,15 @@
 """InMemoryStore-specific tests.
 
 Behavioral conformance against the :class:`Store` protocol lives in
-``tests/test_stores_conformance.py`` (parametrized over both backends).
-This file holds tests that exercise InMemory-only mechanics:
-
-- Negative-``ttl`` shortcut for expired records — RedisStore's Lua
-  ``acquire`` rejects ``ttl_ms <= 0``, so this trick is intentionally
-  not portable. Slice 7 (issue #17) will add real-time TTL tests
-  covering both backends.
-- ``asyncio.Lock``-based concurrency — slice 6 (issue #17) adds the
-  same concurrency assertion against ``RedisStore``'s Lua ``EVAL``.
+``tests/test_stores_conformance.py`` (parametrized over both backends);
+that file also covers single-process concurrency. This file holds
+tests that exercise InMemory-only mechanics — specifically the
+negative-``ttl`` shortcut for expired records, which RedisStore's Lua
+``acquire`` rejects (``ttl_ms <= 0``) by design. Slice 7 (issue #17)
+will add real-time TTL tests covering both backends.
 """
 
 from __future__ import annotations
-
-import asyncio
-from collections import Counter
 
 from fastapi_idempotency import (
     AcquireOutcome,
@@ -42,15 +36,3 @@ async def test_get_returns_none_for_an_expired_record() -> None:
     await store.acquire(KEY, FP, ttl=-1.0)
 
     assert await store.get(KEY) is None
-
-
-async def test_concurrent_acquire_yields_exactly_one_created() -> None:
-    store = InMemoryStore()
-
-    results = await asyncio.gather(
-        *(store.acquire(KEY, FP, ttl=30.0) for _ in range(10)),
-    )
-
-    outcomes = Counter(r.outcome for r in results)
-    assert outcomes[AcquireOutcome.CREATED] == 1
-    assert outcomes[AcquireOutcome.IN_FLIGHT] == 9

--- a/tests/test_stores_memory.py
+++ b/tests/test_stores_memory.py
@@ -1,93 +1,31 @@
-"""Acceptance tests for InMemoryStore."""
+"""InMemoryStore-specific tests.
+
+Behavioral conformance against the :class:`Store` protocol lives in
+``tests/test_stores_conformance.py`` (parametrized over both backends).
+This file holds tests that exercise InMemory-only mechanics:
+
+- Negative-``ttl`` shortcut for expired records — RedisStore's Lua
+  ``acquire`` rejects ``ttl_ms <= 0``, so this trick is intentionally
+  not portable. Slice 7 (issue #17) will add real-time TTL tests
+  covering both backends.
+- ``asyncio.Lock``-based concurrency — slice 6 (issue #17) adds the
+  same concurrency assertion against ``RedisStore``'s Lua ``EVAL``.
+"""
 
 from __future__ import annotations
 
 import asyncio
-import time
 from collections import Counter
-
-import pytest
 
 from fastapi_idempotency import (
     AcquireOutcome,
-    CachedResponse,
     Fingerprint,
     IdempotencyKey,
-    IdempotencyState,
     InMemoryStore,
-    StoreError,
 )
 
-KEY = IdempotencyKey("order-123")
-FP = Fingerprint("abc")
-RESPONSE = CachedResponse(
-    status_code=201,
-    headers=((b"content-type", b"application/json"),),
-    body=b'{"id": 1}',
-)
-
-
-async def test_acquire_returns_created_on_first_call() -> None:
-    store = InMemoryStore()
-
-    result = await store.acquire(KEY, FP, ttl=30.0)
-
-    assert result.outcome is AcquireOutcome.CREATED
-    assert result.record.key == KEY
-    assert result.record.fingerprint == FP
-    assert result.record.state is IdempotencyState.IN_FLIGHT
-    assert result.record.response is None
-    assert result.record.expires_at > time.time()
-
-
-async def test_get_returns_none_for_unknown_key() -> None:
-    store = InMemoryStore()
-
-    assert await store.get(KEY) is None
-
-
-async def test_get_returns_the_record_for_a_known_key() -> None:
-    store = InMemoryStore()
-    acquired = await store.acquire(KEY, FP, ttl=30.0)
-
-    fetched = await store.get(KEY)
-
-    assert fetched == acquired.record
-
-
-async def test_release_removes_an_in_flight_slot() -> None:
-    store = InMemoryStore()
-    await store.acquire(KEY, FP, ttl=30.0)
-
-    await store.release(KEY)
-
-    assert await store.get(KEY) is None
-
-
-async def test_release_on_a_missing_key_is_a_noop() -> None:
-    store = InMemoryStore()
-
-    await store.release(KEY)  # must not raise
-
-
-async def test_acquire_with_same_key_and_fingerprint_returns_in_flight() -> None:
-    store = InMemoryStore()
-    await store.acquire(KEY, FP, ttl=30.0)
-
-    result = await store.acquire(KEY, FP, ttl=30.0)
-
-    assert result.outcome is AcquireOutcome.IN_FLIGHT
-    assert result.record.state is IdempotencyState.IN_FLIGHT
-
-
-async def test_acquire_with_different_fingerprint_returns_mismatch() -> None:
-    store = InMemoryStore()
-    await store.acquire(KEY, FP, ttl=30.0)
-
-    result = await store.acquire(KEY, Fingerprint("other"), ttl=30.0)
-
-    assert result.outcome is AcquireOutcome.MISMATCH
-    assert result.record.fingerprint == FP
+KEY = IdempotencyKey("order-memory")
+FP = Fingerprint("fp-memory")
 
 
 async def test_acquire_on_an_expired_record_creates_a_fresh_slot() -> None:
@@ -104,37 +42,6 @@ async def test_get_returns_none_for_an_expired_record() -> None:
     await store.acquire(KEY, FP, ttl=-1.0)
 
     assert await store.get(KEY) is None
-
-
-async def test_complete_transitions_in_flight_to_completed_with_response() -> None:
-    store = InMemoryStore()
-    await store.acquire(KEY, FP, ttl=30.0)
-
-    await store.complete(KEY, RESPONSE, ttl=3600.0)
-
-    record = await store.get(KEY)
-    assert record is not None
-    assert record.state is IdempotencyState.COMPLETED
-    assert record.response == RESPONSE
-    assert record.fingerprint == FP  # preserved from the in-flight record
-
-
-async def test_acquire_after_complete_returns_replay() -> None:
-    store = InMemoryStore()
-    await store.acquire(KEY, FP, ttl=30.0)
-    await store.complete(KEY, RESPONSE, ttl=3600.0)
-
-    result = await store.acquire(KEY, FP, ttl=30.0)
-
-    assert result.outcome is AcquireOutcome.REPLAY
-    assert result.record.response == RESPONSE
-
-
-async def test_complete_raises_store_error_on_unknown_key() -> None:
-    store = InMemoryStore()
-
-    with pytest.raises(StoreError):
-        await store.complete(KEY, RESPONSE, ttl=3600.0)
 
 
 async def test_concurrent_acquire_yields_exactly_one_created() -> None:

--- a/tests/test_stores_redis.py
+++ b/tests/test_stores_redis.py
@@ -14,9 +14,13 @@ import re
 import pytest
 import redis.asyncio
 
-from fastapi_idempotency import AcquireOutcome
+from fastapi_idempotency import AcquireOutcome, IdempotencyKey, StoreError
 from fastapi_idempotency.stores import redis as redis_module
-from fastapi_idempotency.stores.redis import _ACQUIRE_LUA, RedisStore
+from fastapi_idempotency.stores.redis import (
+    _ACQUIRE_LUA,
+    RedisStore,
+    _wrap_redis_error,
+)
 
 
 def test_redis_store_module_imports() -> None:
@@ -60,3 +64,31 @@ def test_lua_outcome_strings_match_enum_values() -> None:
     expected = {outcome.value for outcome in AcquireOutcome}
 
     assert found == expected
+
+
+def test_namespacing_uses_default_prefix() -> None:
+    """Stored Redis keys are prefixed with ``{namespace}:``."""
+    client = redis.asyncio.Redis()
+    store = RedisStore(client)
+
+    # ``_key`` is private, but the formatting is part of the wire contract
+    # operators rely on for Redis introspection (KEYS pattern, SCAN, etc.).
+    assert store._key(IdempotencyKey("abc-123")) == "idem:abc-123"
+
+
+def test_namespacing_uses_custom_prefix() -> None:
+    client = redis.asyncio.Redis()
+    store = RedisStore(client, namespace="myapp")
+
+    assert store._key(IdempotencyKey("abc-123")) == "myapp:abc-123"
+
+
+def test_wrap_redis_error_returns_store_error_with_op_in_message() -> None:
+    """Each method's except sites translate redis-py exceptions to StoreError
+    with the op name in the message — operators get a breadcrumb without
+    parsing the traceback."""
+    err = _wrap_redis_error("acquire", RuntimeError("connection refused"))
+
+    assert isinstance(err, StoreError)
+    assert "Redis acquire failed" in str(err)
+    assert "connection refused" in str(err)

--- a/tests/test_stores_redis.py
+++ b/tests/test_stores_redis.py
@@ -3,24 +3,36 @@
 The cross-store conformance suite (slice 5) covers the actual store
 behavior against a testcontainers Redis. The tests here pin module-level
 invariants — namespace defaults, the Lua/enum agreement, the
-``decode_responses`` guard — so they catch regressions without needing
-container infrastructure.
+``decode_responses`` guard, and per-method error-wrapping — so they
+catch regressions without needing container infrastructure.
 """
 
 from __future__ import annotations
 
 import re
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import redis.asyncio
+from redis.exceptions import RedisError
 
-from fastapi_idempotency import AcquireOutcome, IdempotencyKey, StoreError
+from fastapi_idempotency import (
+    AcquireOutcome,
+    CachedResponse,
+    Fingerprint,
+    IdempotencyKey,
+    StoreError,
+)
 from fastapi_idempotency.stores import redis as redis_module
+from fastapi_idempotency.stores._serde import encode_record
 from fastapi_idempotency.stores.redis import (
     _ACQUIRE_LUA,
     RedisStore,
     _wrap_redis_error,
 )
+from fastapi_idempotency.types import IdempotencyRecord, IdempotencyState
 
 
 def test_redis_store_module_imports() -> None:
@@ -92,3 +104,128 @@ def test_wrap_redis_error_returns_store_error_with_op_in_message() -> None:
     assert isinstance(err, StoreError)
     assert "Redis acquire failed" in str(err)
     assert "connection refused" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# Fault-injection: per-method error wrapping
+#
+# Each ``except (RedisError, OSError)`` site in ``RedisStore`` translates
+# the underlying exception into a ``StoreError`` carrying its own op name.
+# Without these tests the op-name strings (``"acquire"``, ``"get"``,
+# ``"complete"``, ``"release"``) are invisible to CI — a typo there only
+# surfaces when an operator reads a 5-line stack trace at 03:00. Stub
+# clients let us probe the wrapping contract per call site without
+# spinning up Redis.
+# ---------------------------------------------------------------------------
+
+
+def _stub_client(
+    *,
+    register_script_returns: tuple[Any, Any] | None = None,
+    hget_returns: Any = None,
+    hget_raises: BaseException | None = None,
+    delete_raises: BaseException | None = None,
+) -> MagicMock:
+    """Build a minimal ``redis.asyncio.Redis``-shaped stub.
+
+    ``register_script_returns`` is a 2-tuple corresponding to the two
+    ``register_script`` calls in ``RedisStore.__init__`` (acquire then
+    complete). ``hget_returns``/``hget_raises`` configure the shared
+    ``hget`` mock; ``delete_raises`` configures ``delete``.
+    """
+    client = MagicMock()
+    encoder = MagicMock()
+    encoder.decode_responses = False
+    client.get_encoder = MagicMock(return_value=encoder)
+    if register_script_returns is None:
+        client.register_script = MagicMock(side_effect=[AsyncMock(), AsyncMock()])
+    else:
+        client.register_script = MagicMock(side_effect=list(register_script_returns))
+    if hget_raises is not None:
+        client.hget = AsyncMock(side_effect=hget_raises)
+    else:
+        client.hget = AsyncMock(return_value=hget_returns)
+    if delete_raises is not None:
+        client.delete = AsyncMock(side_effect=delete_raises)
+    else:
+        client.delete = AsyncMock(return_value=1)
+    return client
+
+
+KEY = IdempotencyKey("k")
+FP = Fingerprint("f")
+RESPONSE = CachedResponse(status_code=200, headers=(), body=b"")
+
+
+def _existing_record_bytes() -> bytes:
+    """An IN_FLIGHT record with future ``expires_at`` for complete-path setup."""
+    return encode_record(
+        IdempotencyRecord(
+            key=KEY,
+            fingerprint=FP,
+            state=IdempotencyState.IN_FLIGHT,
+            created_at=time.time(),
+            expires_at=time.time() + 30.0,
+            response=None,
+        ),
+    )
+
+
+async def test_acquire_wraps_redis_error_with_op_name() -> None:
+    acquire_script = AsyncMock(side_effect=RedisError("boom"))
+    client = _stub_client(register_script_returns=(acquire_script, AsyncMock()))
+    store = RedisStore(client)
+
+    with pytest.raises(StoreError, match="Redis acquire failed"):
+        await store.acquire(KEY, FP, ttl=30.0)
+
+
+async def test_get_wraps_redis_error_with_op_name() -> None:
+    client = _stub_client(hget_raises=RedisError("boom"))
+    store = RedisStore(client)
+
+    with pytest.raises(StoreError, match="Redis get failed"):
+        await store.get(KEY)
+
+
+async def test_complete_wraps_hget_redis_error_with_op_name() -> None:
+    client = _stub_client(hget_raises=RedisError("boom"))
+    store = RedisStore(client)
+
+    with pytest.raises(StoreError, match="Redis complete failed"):
+        await store.complete(KEY, RESPONSE, ttl=3600.0)
+
+
+async def test_complete_wraps_script_redis_error_with_op_name() -> None:
+    """The complete path has TWO redis-py call sites (HGET then EVAL).
+    Each must wrap independently — covers the second except path."""
+    complete_script = AsyncMock(side_effect=RedisError("boom"))
+    client = _stub_client(
+        register_script_returns=(AsyncMock(), complete_script),
+        hget_returns=_existing_record_bytes(),
+    )
+    store = RedisStore(client)
+
+    with pytest.raises(StoreError, match="Redis complete failed"):
+        await store.complete(KEY, RESPONSE, ttl=3600.0)
+
+
+async def test_release_wraps_redis_error_with_op_name() -> None:
+    client = _stub_client(delete_raises=RedisError("boom"))
+    store = RedisStore(client)
+
+    with pytest.raises(StoreError, match="Redis release failed"):
+        await store.release(KEY)
+
+
+async def test_acquire_wraps_oserror_with_op_name() -> None:
+    """The except clause catches both RedisError and OSError — the second
+    half (OSError, e.g. socket-level errors) needs its own probe.
+    Picking acquire as the representative; the other 4 use identical
+    ``except (RedisError, OSError)`` shape."""
+    acquire_script = AsyncMock(side_effect=OSError("connection refused"))
+    client = _stub_client(register_script_returns=(acquire_script, AsyncMock()))
+    store = RedisStore(client)
+
+    with pytest.raises(StoreError, match="Redis acquire failed"):
+        await store.acquire(KEY, FP, ttl=30.0)

--- a/tests/test_stores_redis.py
+++ b/tests/test_stores_redis.py
@@ -1,21 +1,62 @@
-"""Import-only smoke test for the Redis store stub.
+"""Tests for the Redis store module that don't require a live Redis.
 
-Touching the module guarantees its top-level statements are measured by
-coverage (otherwise the stub would show 0%, dragging total coverage down).
-The class itself is marked ``# pragma: no cover`` until v0.2.0 lands the
-real implementation.
+The cross-store conformance suite (slice 5) covers the actual store
+behavior against a testcontainers Redis. The tests here pin module-level
+invariants — namespace defaults, the Lua/enum agreement, the
+``decode_responses`` guard — so they catch regressions without needing
+container infrastructure.
 """
 
 from __future__ import annotations
 
+import re
+
+import pytest
+import redis.asyncio
+
+from fastapi_idempotency import AcquireOutcome
 from fastapi_idempotency.stores import redis as redis_module
+from fastapi_idempotency.stores.redis import _ACQUIRE_LUA, RedisStore
 
 
-def test_redis_store_module_imports_without_redis_extra() -> None:
-    """Module must import even when the ``redis`` extra isn't installed.
-
-    Real ``redis.asyncio.Redis`` is referenced only under ``TYPE_CHECKING``;
-    the runtime import path doesn't touch it, so the module is safe to
-    import in environments without the optional dependency.
-    """
+def test_redis_store_module_imports() -> None:
+    """Module must import cleanly. Sanity that top-level imports work."""
     assert redis_module.RedisStore is not None
+
+
+def test_namespace_default_is_idem() -> None:
+    """Default namespace per docstring is 'idem'."""
+    client = redis.asyncio.Redis()  # no connect; constructor only
+    store = RedisStore(client)
+
+    assert store.namespace == "idem"
+
+
+def test_namespace_can_be_overridden() -> None:
+    client = redis.asyncio.Redis()
+
+    store = RedisStore(client, namespace="myapp")
+
+    assert store.namespace == "myapp"
+
+
+def test_constructor_rejects_decode_responses_true() -> None:
+    """A client with ``decode_responses=True`` would silently corrupt
+    the msgpack codec — fail loud at construction instead."""
+    client = redis.asyncio.Redis(decode_responses=True)
+
+    with pytest.raises(ValueError, match="decode_responses=False"):
+        RedisStore(client)
+
+
+def test_lua_outcome_strings_match_enum_values() -> None:
+    """The Lua acquire script returns one of four outcome strings.
+
+    These literals MUST match :class:`AcquireOutcome`'s ``.value`` strings
+    exactly, otherwise a rename in the enum will silently break the
+    acquire-result decode in production.
+    """
+    found = set(re.findall(r"return \{'([a-z_]+)'", _ACQUIRE_LUA))
+    expected = {outcome.value for outcome in AcquireOutcome}
+
+    assert found == expected

--- a/tests/test_stores_redis_concurrent.py
+++ b/tests/test_stores_redis_concurrent.py
@@ -1,0 +1,100 @@
+"""Cross-process concurrent acquire — the distributed-locking proof.
+
+The single-process concurrent test in ``test_stores_conformance.py``
+covers ``asyncio.Lock`` (for InMemory) and Lua-atomicity + redis-py
+connection-pool behavior (for Redis, but all coros share one client).
+This file adds the test that actually justifies the Redis dependency:
+N independent OS processes, each with its own client and connection
+pool, racing on the same key. Exactly one wins CREATED — the rest see
+IN_FLIGHT. That property is what RedisStore exists to provide.
+
+``spawn`` start method (not ``fork``): workers begin with no shared
+state from the parent — clean event loop, fresh redis-py pool. Slower
+on Linux (~500 ms vs ~50 ms for fork), but sidesteps the fork-of-
+asyncio-loop hazards (lingering selectors, half-initialized pools)
+that fork inherits.
+
+A ``Manager().Barrier(N)`` synchronizes all N workers right before
+``acquire``. Without it the test could pass even when workers run
+strictly serially (one finishes before the next imports redis-py) —
+the assertions would still hold, but no actual race would have
+happened. The barrier converts the test from "probabilistically
+covers concurrent claim" to "deterministically proves it".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import multiprocessing as mp
+from collections import Counter
+from concurrent.futures import ProcessPoolExecutor
+from typing import Any
+
+import pytest
+
+from _redis_helpers import make_async_client
+from fastapi_idempotency import AcquireOutcome, Fingerprint, IdempotencyKey
+from fastapi_idempotency.stores.redis import RedisStore
+
+_KEY = "cross-process-acquire"
+_FP = "fp-cross"
+_TTL = 30.0
+_N = 10
+_BARRIER_TIMEOUT_S = 10.0
+
+
+def _acquire_in_subprocess(redis_url: str, barrier: Any) -> str:
+    """Worker entry: open own client, sync on barrier, acquire, return outcome.
+
+    Module-level so spawn can pickle it by qualified name. Returns
+    ``outcome.value`` (a string) rather than the enum member because
+    pickling enums across the process boundary works but is fragile to
+    re-imports — strings cross unambiguously.
+    """
+
+    async def _run() -> str:
+        client = make_async_client(redis_url)
+        try:
+            store = RedisStore(client)
+            # All N workers wait here until everyone has reached this
+            # point, then release simultaneously. Without the barrier
+            # the test could pass trivially with strictly serial
+            # execution; with it, the race is guaranteed.
+            barrier.wait(timeout=_BARRIER_TIMEOUT_S)
+            result = await store.acquire(
+                IdempotencyKey(_KEY),
+                Fingerprint(_FP),
+                ttl=_TTL,
+            )
+            return result.outcome.value
+        finally:
+            await client.aclose()
+
+    return asyncio.run(_run())
+
+
+@pytest.mark.redis
+@pytest.mark.usefixtures("redis_client")
+async def test_acquire_serializes_across_processes(redis_url: str) -> None:
+    """N OS processes race for one key — exactly one wins CREATED.
+
+    ``redis_client`` is requested via ``usefixtures`` purely for its
+    pre-test FLUSHDB on DB 15; the subprocess workers connect by URL
+    and don't share the parent's client. The fixture's aclose runs
+    after this test independently.
+    """
+    spawn_ctx = mp.get_context("spawn")
+    loop = asyncio.get_running_loop()
+    with spawn_ctx.Manager() as manager:
+        barrier = manager.Barrier(_N)
+        with ProcessPoolExecutor(max_workers=_N, mp_context=spawn_ctx) as pool:
+            outcomes = await asyncio.gather(
+                *(
+                    loop.run_in_executor(pool, _acquire_in_subprocess, redis_url, barrier)
+                    for _ in range(_N)
+                ),
+            )
+
+    counts = Counter(outcomes)
+    assert counts[AcquireOutcome.CREATED.value] == 1
+    assert counts[AcquireOutcome.IN_FLIGHT.value] == _N - 1

--- a/tests/test_stores_redis_integration.py
+++ b/tests/test_stores_redis_integration.py
@@ -1,0 +1,20 @@
+"""Integration tests requiring a live Redis (via testcontainers).
+
+Marked ``@pytest.mark.redis`` so they are skipped when Docker is
+unavailable or when running ``pytest -m "not redis"`` (the existing CI
+default).
+"""
+
+from __future__ import annotations
+
+import pytest
+import redis.asyncio
+
+
+# TODO(slice-5): the cross-store conformance suite will exercise the same
+# connectivity path as this smoke. Drop this file (or keep only as a
+# fast-fail gate before the heavier suite) once slice 5 lands.
+@pytest.mark.redis
+async def test_redis_smoke_ping(redis_client: redis.asyncio.Redis) -> None:
+    """Smoke: testcontainers Redis is reachable and responsive."""
+    assert await redis_client.ping() is True

--- a/tests/test_stores_redis_integration.py
+++ b/tests/test_stores_redis_integration.py
@@ -1,20 +1,116 @@
-"""Integration tests requiring a live Redis (via testcontainers).
+"""Redis-only tests that don't fit the cross-store conformance suite.
 
-Marked ``@pytest.mark.redis`` so they are skipped when Docker is
-unavailable or when running ``pytest -m "not redis"`` (the existing CI
-default).
+Marked ``@pytest.mark.redis``. Two purposes:
+
+- Smoke: a fast-fail connectivity gate before the heavier conformance
+  suite spins up.
+- Defense-in-depth coverage: backend-specific branches (e.g. the
+  Python-side ``is_expired`` filter in ``RedisStore.get``) that
+  conformance can't reach because they only fire under sub-millisecond
+  races between PEXPIRE and HGET.
 """
 
 from __future__ import annotations
 
+import time
+
 import pytest
 import redis.asyncio
 
+from fastapi_idempotency import (
+    CachedResponse,
+    Fingerprint,
+    IdempotencyKey,
+    IdempotencyRecord,
+    IdempotencyState,
+    StoreError,
+)
+from fastapi_idempotency.stores._serde import encode_record
+from fastapi_idempotency.stores.redis import RedisStore
 
-# TODO(slice-5): the cross-store conformance suite will exercise the same
-# connectivity path as this smoke. Drop this file (or keep only as a
-# fast-fail gate before the heavier suite) once slice 5 lands.
+
 @pytest.mark.redis
 async def test_redis_smoke_ping(redis_client: redis.asyncio.Redis) -> None:
     """Smoke: testcontainers Redis is reachable and responsive."""
     assert await redis_client.ping() is True
+
+
+@pytest.mark.redis
+async def test_get_filters_python_side_expired_record(
+    redis_client: redis.asyncio.Redis,
+) -> None:
+    """``RedisStore.get`` returns None for records whose ``expires_at``
+    has elapsed by the Python clock, even when PEXPIRE hasn't yet fired
+    on the Redis side.
+
+    Synthetic test: writes the hash directly via HSET with a stale
+    ``expires_at`` and a long PEXPIRE TTL. PEXPIRE alone would keep
+    the key around; only the Python-side ``is_expired`` filter in
+    ``get`` (defense-in-depth against the sub-millisecond race
+    between PEXPIRE and HGET) returns None.
+    """
+    store = RedisStore(redis_client)
+    key = IdempotencyKey("python-side-expired")
+    full_key = store._key(key)
+
+    expired_record = IdempotencyRecord(
+        key=key,
+        fingerprint=Fingerprint("fp"),
+        state=IdempotencyState.IN_FLIGHT,
+        created_at=time.time() - 100,
+        expires_at=time.time() - 1.0,  # already elapsed by Python clock
+        response=None,
+    )
+    await redis_client.hset(
+        full_key,
+        mapping={
+            b"fp": b"fp",
+            b"state": b"in_flight",
+            b"data": encode_record(expired_record),
+        },
+    )
+    # Server-side TTL high so PEXPIRE doesn't evict the key — only the
+    # Python-clock check inside ``get`` should turn it into None.
+    await redis_client.pexpire(full_key, 60_000)
+
+    assert await store.get(key) is None
+
+
+@pytest.mark.redis
+async def test_complete_raises_on_python_side_expired_record(
+    redis_client: redis.asyncio.Redis,
+) -> None:
+    """``RedisStore.complete`` raises ``StoreError`` when the existing
+    record is expired by Python clock, even if PEXPIRE hasn't fired.
+
+    Symmetric with ``test_get_filters_python_side_expired_record``: the
+    in-flight TTL race that masks an expired slot from server-side
+    eviction is the exact scenario the defense exists to catch — without
+    it, ``complete`` would silently overwrite an "expired but still in
+    Redis" slot, exactly the bug fixed in InMemoryStore in slice 7.
+    """
+    store = RedisStore(redis_client)
+    key = IdempotencyKey("python-side-expired-complete")
+    full_key = store._key(key)
+
+    expired_record = IdempotencyRecord(
+        key=key,
+        fingerprint=Fingerprint("fp"),
+        state=IdempotencyState.IN_FLIGHT,
+        created_at=time.time() - 100,
+        expires_at=time.time() - 1.0,  # already elapsed by Python clock
+        response=None,
+    )
+    await redis_client.hset(
+        full_key,
+        mapping={
+            b"fp": b"fp",
+            b"state": b"in_flight",
+            b"data": encode_record(expired_record),
+        },
+    )
+    await redis_client.pexpire(full_key, 60_000)  # PEXPIRE not yet fired
+
+    response = CachedResponse(status_code=200, headers=(), body=b"")
+    with pytest.raises(StoreError):
+        await store.complete(key, response, ttl=3600.0)

--- a/tests/test_stores_serde.py
+++ b/tests/test_stores_serde.py
@@ -1,0 +1,395 @@
+"""Round-trip and validation tests for the msgpack record codec."""
+
+from __future__ import annotations
+
+import msgpack
+import pytest
+
+from fastapi_idempotency import (
+    CachedResponse,
+    Fingerprint,
+    IdempotencyKey,
+    IdempotencyRecord,
+    IdempotencyState,
+    StoreError,
+)
+from fastapi_idempotency.stores._serde import (
+    SCHEMA_VERSION,
+    decode_record,
+    encode_record,
+)
+
+
+def _make_record(*, response: CachedResponse | None = None) -> IdempotencyRecord:
+    state = IdempotencyState.COMPLETED if response is not None else IdempotencyState.IN_FLIGHT
+    return IdempotencyRecord(
+        key=IdempotencyKey("order-123"),
+        fingerprint=Fingerprint("0123abcdef"),
+        state=state,
+        created_at=1234567890.123,
+        expires_at=1234567920.456,
+        response=response,
+    )
+
+
+def _envelope_with_data(data: dict[str, object]) -> bytes:
+    """Build a v=1 envelope with the given record-data dict."""
+    return msgpack.packb({"v": SCHEMA_VERSION, "data": data}, use_bin_type=True)  # type: ignore[no-any-return]
+
+
+def _valid_record_data(**overrides: object) -> dict[str, object]:
+    """Baseline valid record dict; tests override single fields to provoke errors."""
+    base: dict[str, object] = {
+        "key": "k",
+        "fingerprint": "fp",
+        "state": "in_flight",
+        "created_at": 1.0,
+        "expires_at": 2.0,
+        "response": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _valid_response_data(**overrides: object) -> dict[str, object]:
+    """Baseline valid response dict for inner CachedResponse fields."""
+    base: dict[str, object] = {
+        "status_code": 200,
+        "headers": [],
+        "body": b"",
+        "media_type": None,
+    }
+    base.update(overrides)
+    return base
+
+
+# === Round-trip ===
+
+
+def test_round_trip_in_flight_record() -> None:
+    original = _make_record()
+
+    decoded = decode_record(encode_record(original))
+
+    assert decoded == original
+
+
+def test_round_trip_completed_with_response() -> None:
+    response = CachedResponse(
+        status_code=201,
+        headers=(
+            (b"content-type", b"application/json"),
+            (b"x-custom", b"value"),
+        ),
+        body=b'{"id": 42}',
+        media_type="application/json",
+    )
+    original = _make_record(response=response)
+
+    decoded = decode_record(encode_record(original))
+
+    assert decoded == original
+    assert decoded.response is not None
+    assert isinstance(decoded.response.headers, tuple)
+    for pair in decoded.response.headers:
+        assert isinstance(pair, tuple)
+        assert isinstance(pair[0], bytes)
+        assert isinstance(pair[1], bytes)
+
+
+def test_round_trip_empty_body_and_headers() -> None:
+    response = CachedResponse(status_code=204, headers=(), body=b"")
+    original = _make_record(response=response)
+
+    decoded = decode_record(encode_record(original))
+
+    assert decoded == original
+
+
+def test_round_trip_preserves_none_response() -> None:
+    record = _make_record()
+
+    decoded = decode_record(encode_record(record))
+
+    assert decoded.response is None
+
+
+# === Schema envelope ===
+
+
+def test_envelope_carries_schema_version() -> None:
+    record = _make_record()
+
+    envelope = msgpack.unpackb(encode_record(record), raw=False)
+
+    assert envelope["v"] == SCHEMA_VERSION
+    assert "data" in envelope
+
+
+def test_decode_rejects_unknown_schema_version() -> None:
+    record = _make_record()
+    envelope = msgpack.unpackb(encode_record(record), raw=False)
+    envelope["v"] = SCHEMA_VERSION + 99
+    bad_bytes = msgpack.packb(envelope, use_bin_type=True)
+
+    with pytest.raises(StoreError, match="unsupported record schema version"):
+        decode_record(bad_bytes)
+
+
+def test_decode_rejects_non_dict_envelope() -> None:
+    bad = msgpack.packb([1, 2, 3], use_bin_type=True)
+
+    with pytest.raises(StoreError, match="not a dict"):
+        decode_record(bad)
+
+
+def test_decode_rejects_envelope_missing_data() -> None:
+    bad = msgpack.packb({"v": SCHEMA_VERSION}, use_bin_type=True)
+
+    with pytest.raises(StoreError, match="missing 'data'"):
+        decode_record(bad)
+
+
+# === Malformed input ===
+
+
+def test_decode_rejects_malformed_bytes() -> None:
+    with pytest.raises(StoreError):
+        decode_record(b"\x00\x01\x02 not msgpack")
+
+
+def test_decode_rejects_empty_bytes() -> None:
+    with pytest.raises(StoreError):
+        decode_record(b"")
+
+
+# === KeyError / ValueError → StoreError contract ===
+
+
+def test_decode_missing_field_raises_store_error() -> None:
+    bad = msgpack.packb(
+        {"v": SCHEMA_VERSION, "data": {"key": "abc"}},  # missing fingerprint, etc
+        use_bin_type=True,
+    )
+
+    with pytest.raises(StoreError, match="invalid record fields"):
+        decode_record(bad)
+
+
+def test_decode_unknown_state_raises_store_error() -> None:
+    bad = _envelope_with_data(_valid_record_data(state="deleted"))
+
+    with pytest.raises(StoreError):
+        decode_record(bad)
+
+
+# === Field type validation ===
+
+
+def test_decode_rejects_int_as_key() -> None:
+    bad = _envelope_with_data(_valid_record_data(key=42))
+
+    with pytest.raises(StoreError):
+        decode_record(bad)
+
+
+def test_decode_rejects_int_as_fingerprint() -> None:
+    bad = _envelope_with_data(_valid_record_data(fingerprint=42))
+
+    with pytest.raises(StoreError):
+        decode_record(bad)
+
+
+def test_decode_rejects_inf_timestamp() -> None:
+    bad = _envelope_with_data(_valid_record_data(created_at=float("inf")))
+
+    with pytest.raises(StoreError):
+        decode_record(bad)
+
+
+def test_decode_rejects_nan_timestamp() -> None:
+    bad = _envelope_with_data(_valid_record_data(expires_at=float("nan")))
+
+    with pytest.raises(StoreError):
+        decode_record(bad)
+
+
+def test_decode_rejects_string_as_timestamp() -> None:
+    bad = _envelope_with_data(_valid_record_data(created_at="never"))
+
+    with pytest.raises(StoreError):
+        decode_record(bad)
+
+
+# === Response field validation ===
+
+
+def test_decode_rejects_invalid_status_code() -> None:
+    bad = _envelope_with_data(
+        _valid_record_data(
+            state="completed",
+            response=_valid_response_data(status_code=999),
+        ),
+    )
+
+    with pytest.raises(StoreError):
+        decode_record(bad)
+
+
+def test_decode_rejects_str_as_body() -> None:
+    bad = _envelope_with_data(
+        _valid_record_data(
+            state="completed",
+            response=_valid_response_data(body="not bytes"),
+        ),
+    )
+
+    with pytest.raises(StoreError):
+        decode_record(bad)
+
+
+def test_decode_rejects_int_as_status_code() -> None:
+    """status_code 200 (int) is valid; True (bool subclass) must not pass."""
+    bad = _envelope_with_data(
+        _valid_record_data(
+            state="completed",
+            response=_valid_response_data(status_code=True),
+        ),
+    )
+
+    with pytest.raises(StoreError):
+        decode_record(bad)
+
+
+# === Header validation (_coerce_header_pairs) ===
+
+
+def test_decode_rejects_3_element_header_pair() -> None:
+    bad = _envelope_with_data(
+        _valid_record_data(
+            state="completed",
+            response=_valid_response_data(headers=[[b"a", b"b", b"c"]]),
+        ),
+    )
+
+    with pytest.raises(StoreError):
+        decode_record(bad)
+
+
+def test_decode_rejects_int_as_header_value() -> None:
+    """Guard against ``bytes(int)`` memory-blow-up: ``bytes(1073741824)`` → 1 GiB."""
+    bad = _envelope_with_data(
+        _valid_record_data(
+            state="completed",
+            response=_valid_response_data(headers=[[b"name", 1073741824]]),
+        ),
+    )
+
+    with pytest.raises(StoreError):
+        decode_record(bad)
+
+
+def test_decode_rejects_str_as_header_name() -> None:
+    bad = _envelope_with_data(
+        _valid_record_data(
+            state="completed",
+            response=_valid_response_data(headers=[["content-type", b"value"]]),
+        ),
+    )
+
+    with pytest.raises(StoreError):
+        decode_record(bad)
+
+
+def test_decode_rejects_oversized_headers_list() -> None:
+    too_many = [[b"x", b"y"] for _ in range(101)]
+    bad = _envelope_with_data(
+        _valid_record_data(
+            state="completed",
+            response=_valid_response_data(headers=too_many),
+        ),
+    )
+
+    with pytest.raises(StoreError):
+        decode_record(bad)
+
+
+# === Forward-compat ===
+
+
+def test_decode_ignores_unknown_data_fields() -> None:
+    """v=2 may add new fields; v=1 readers should not crash on them."""
+    record = _make_record()
+    encoded = encode_record(record)
+    envelope = msgpack.unpackb(encoded, raw=False)
+    envelope["data"]["future_field"] = "extra"
+    bytes_with_extra = msgpack.packb(envelope, use_bin_type=True)
+
+    decoded = decode_record(bytes_with_extra)
+
+    assert decoded == record
+
+
+# === Wire-format pinning (silent rename detector) ===
+
+
+def test_wire_format_state_strings_are_stable() -> None:
+    """State enum values are wire format. Renames must trigger a v=2 bump."""
+    in_flight = encode_record(_make_record())
+    assert b"in_flight" in in_flight
+
+    completed_response = CachedResponse(status_code=200, headers=(), body=b"")
+    completed = encode_record(_make_record(response=completed_response))
+    assert b"completed" in completed
+
+
+# === Determinism ===
+
+
+def test_encode_is_deterministic() -> None:
+    """Same input → same bytes. Required for cross-language msgpack peers."""
+    record = _make_record()
+
+    assert encode_record(record) == encode_record(record)
+
+
+def test_encode_high_precision_timestamp_is_deterministic() -> None:
+    """High-precision timestamps must round-trip bit-exactly across encodes.
+
+    Cross-language msgpack peers (Rust ``rmp-serde``, Go ``msgpack/v5``) may
+    round-trip floats through float32 paths in mixed-language deployments;
+    pinning a determinism test now locks the contract for v=1 so any future
+    drift surfaces as a failing test instead of silent data-store corruption.
+    """
+    record = IdempotencyRecord(
+        key=IdempotencyKey("k"),
+        fingerprint=Fingerprint("fp"),
+        state=IdempotencyState.IN_FLIGHT,
+        created_at=1234567890.123456789,
+        expires_at=1234567920.987654321,
+        response=None,
+    )
+
+    a = encode_record(record)
+    b = encode_record(record)
+
+    assert a == b
+
+    decoded = decode_record(a)
+    assert decoded.created_at == record.created_at
+    assert decoded.expires_at == record.expires_at
+
+
+# === Resource limits ===
+
+
+def test_decode_rejects_oversized_body() -> None:
+    """Body > 1 MiB (max_bin_len) must be rejected by msgpack unpack."""
+    huge_body = b"x" * (1024 * 1024 + 100)
+    record = _make_record(
+        response=CachedResponse(status_code=200, headers=(), body=huge_body),
+    )
+    encoded = encode_record(record)  # encoder has no limit
+
+    with pytest.raises(StoreError):
+        decode_record(encoded)


### PR DESCRIPTION
Closes #17

## Summary

Implements `RedisStore` distributed backend — atomic Lua `acquire` so concurrent workers cannot double-claim, full `Store` protocol conformance verified by a parametrized cross-store suite, and CI now runs against a real Redis service container on every supported Python version.

- **`RedisStore`** behind the new `[redis]` extra, exported lazily via PEP 562 `__getattr__` (no redis-py import for users on the bare install). Atomic `acquire` as a single Lua `EVAL` (HMGET to close eviction-race holes); `get`/`complete`/`release` with Python-side `is_expired` defense-in-depth. msgpack codec (`stores/_serde.py`) with v1 envelope and bounded payload size.
- **Cross-store conformance suite** (`tests/test_stores_conformance.py`) parametrized over `InMemoryStore` and `RedisStore` — 21 tests covering acquire/get/complete/release classification, identity preservation, state-machine edges, single-process concurrency, and TTL expiry under real `asyncio.sleep`. Slow tests carry `@pytest.mark.slow`; redis variants carry `@pytest.mark.redis`. Cross-process distributed-locking proof in `tests/test_stores_redis_concurrent.py` (10 spawn'd processes + `Manager().Barrier`).
- **CI matrix runs the full suite (incl. `@pytest.mark.redis` and `@pytest.mark.slow`) against a Redis service container on Python 3.10/3.11/3.12/3.13.** The 95% coverage gate fires on every matrix job — RedisStore parity bugs specific to a single Python version are caught at PR time rather than at upgrade time. `REDIS_URL` env-var escape hatch in conftest also lets dev hosts with broken Docker bridge networking point at any reachable Redis; defaults to DB 15 to keep `FLUSHDB` blast radius off operators' DB 0.
- **`InMemoryStore.complete`** now raises `StoreError` on expired records (matches `RedisStore` and the protocol contract — caught by the conformance suite during slice 7).

## Test plan

- [x] `pytest -m "not redis"` — InMemory + middleware path, 103 passed locally
- [x] `REDIS_URL=redis://localhost:6379 REDIS_TESTS_REQUIRED=1 pytest --cov` — full suite + coverage gate, 128 passed locally, RedisStore 100% covered, total 95.22%
- [x] CI matrix passes coverage gate on all 4 Python versions (3.10/3.11/3.12/3.13) with redis service container
- [x] \`from fastapi_idempotency import RedisStore\` works only when \`[redis]\` extra is installed (lazy export verified)
- [x] cross-process test stable (5/5 stability runs at ~1.2s each with barrier)