### PR TITLE
feat(streaming): pass streaming responses through with Idempotency-Stored: false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Streaming response pass-through (#18). FastAPI / Starlette
+  `StreamingResponse` (and any ASGI app emitting `more_body=True` on
+  the first body chunk) now flows through the middleware live instead
+  of being buffered into memory. Streamed responses carry an
+  `Idempotency-Stored: false` header so retries know they won't replay,
+  and the in-flight slot is released — a stream cannot be cached.
+  Detection defers `http.response.start` until the first body chunk
+  so the header can be injected before start hits the wire.
+  Non-streaming responses keep the v0.1.0 caching/replay behavior
+  unchanged. The `Idempotency-Stored: false` header now carries a
+  union meaning ("response will not replay on retry"): emitted both
+  for streaming pass-through and for the v0.1.0 storage-failure path.
 - `RedisStore` — distributed `Store` backend backed by Redis (#17).
   Atomic `acquire` via a single Lua `EVAL` so concurrent workers cannot
   double-claim a key; `get` / `complete` / `release` are straightforward
@@ -50,6 +62,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The internal request-body replay no longer raises `RuntimeError` on
+  the second `receive()` call. Subsequent calls now forward to the
+  original ASGI `receive`, so apps that listen for `http.disconnect`
+  during streaming (e.g. Starlette's `StreamingResponse` background
+  task) work correctly (#18).
 - `InMemoryStore.complete` now raises `StoreError` on expired records
   (matching `RedisStore` and the `Store` protocol contract). Previously
   it silently overwrote the expired in-flight slot with a fresh

--- a/README.md
+++ b/README.md
@@ -126,7 +126,14 @@ the `Idempotency-Key` header. Outcomes:
 | Same key + same body, after the first completed | Cached response with `Idempotent-Replayed: true` header |
 | Same key + different body | `422 Unprocessable Entity` |
 | Handler returned 5xx | Slot released; a retry will run the handler again. |
-| Handler succeeded but the store failed to persist | Response delivered with `Idempotency-Stored: false` header |
+| Handler returned a streaming response (`StreamingResponse`, SSE, file download) | Forwarded live; not cached. Slot released, retries run the handler again. |
+| Storage failed after a successful response, or any other path that won't replay on retry | `Idempotency-Stored: false` header on the response |
+
+The `Idempotency-Stored: false` header is a union signal: it appears
+on streaming pass-through, on storage-failure delivery, and on the
+synthesized 500 when the handler emits no response. In every case it
+means the same thing for the caller: "this response will not replay
+on retry — the slot is gone."
 
 Safe methods (GET/HEAD/OPTIONS), requests without an `Idempotency-Key`,
 and requests over `max_body_bytes` pass through untouched.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -157,7 +157,56 @@ layer, not the source of truth for "is this expired".
 
 ## Streaming response pass-through
 
-_To be written during v0.2.0._
+**Status: v0.2.0.**
+
+The middleware can't cache a streaming response — by definition the
+body is produced incrementally, often larger than memory can buffer
+(SSE feeds, file downloads, long-poll). Buffering would either OOM
+the worker or delay the first byte until the stream finishes,
+defeating the point of streaming. Issue #18 chose to **forward live
+and skip caching**: the slot is released, the response carries
+`Idempotency-Stored: false`, and retries run the handler again.
+
+### Detection: deferred-start with one-tick peek
+
+ASGI delivers the response as a sequence of messages: one
+`http.response.start`, then one or more `http.response.body` with
+`more_body=True/False`. The streaming signal is `more_body=True` on
+the first body chunk — but by the time it arrives, `start` has
+typically already been forwarded, and we can no longer inject the
+`Idempotency-Stored` header into start's headers.
+
+Solution: `_ResponseInterceptor` defers `http.response.start` until the
+first body chunk. On `more_body=True` we patch the deferred start
+with the header and forward it live, followed by the body chunk;
+subsequent messages take the streaming branch and pass through
+verbatim. On `more_body=False` we treat the response as single-chunk,
+buffer the body, and let the middleware emit a fresh start+body pair
+after deciding cache vs. release (the v0.1.0 path).
+
+The deferral is "until the first body chunk" — possibly many
+event-loop ticks if the handler does work between `start` and the
+first body emission. Apps that emit `start` for back-pressure
+headers and only later produce data still work correctly: the
+detection waits for the first body, not a fixed time.
+
+### Why `Idempotency-Stored: false` is reused (not a new header)
+
+The semantic of `Idempotency-Stored: false` is "this response will
+not replay on retry — the slot is gone." That holds for both paths
+that emit it: storage failure (v0.1.0) and streaming pass-through
+(v0.2.0). Inventing a separate header (e.g., `Idempotency-Streamed`)
+would force clients to handle two signals carrying the same
+operational meaning. The header is documented as a union in README.
+
+### Invariant: cached responses are never streams
+
+`store.complete` is unreachable for streamed responses (`_run_and_cache`
+returns immediately on `interceptor.streamed`). So every `CachedResponse`
+in the store represents a single buffered frame — REPLAY can emit
+them via `_send_response` without per-record streaming logic. Future
+contributors adding a `complete_streaming` path would have to
+preserve this invariant or rework the REPLAY emit.
 
 ## Why msgpack over JSON
 

--- a/src/fastapi_idempotency/body_buffer.py
+++ b/src/fastapi_idempotency/body_buffer.py
@@ -43,22 +43,30 @@ async def buffer_request_body(
             break
 
     body = b"".join(chunks)
-    return body, _Replay(body)
+    return body, _Replay(body, receive)
 
 
 class _Replay:
-    """One-shot ASGI ``receive`` yielding a buffered body once."""
+    """ASGI ``receive`` replay: yields the buffered body once, then forwards
+    subsequent calls to the original ``receive``.
 
-    def __init__(self, body: bytes) -> None:
+    Forwarding (rather than raising on the second call) keeps
+    disconnect-listening alive — Starlette's ``StreamingResponse``
+    starts a background ``receive()`` task that needs to observe
+    ``http.disconnect``.
+    """
+
+    def __init__(self, body: bytes, original: Receive) -> None:
         self._message: Message = {
             "type": "http.request",
             "body": body,
             "more_body": False,
         }
         self._consumed = False
+        self._original = original
 
     async def __call__(self) -> Message:
-        if self._consumed:
-            raise RuntimeError("replay receive() called twice")
-        self._consumed = True
-        return self._message
+        if not self._consumed:
+            self._consumed = True
+            return self._message
+        return await self._original()

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -157,39 +157,59 @@ class IdempotencyMiddleware:
         send: Send,
         key: IdempotencyKey,
     ) -> None:
-        capturer = _ResponseCapturer()
+        interceptor = _ResponseInterceptor(send)
         try:
-            await self.app(scope, replay, capturer)
+            await self.app(scope, replay, interceptor)
         except Exception:
-            # Handler raised before producing a response. Release the slot
-            # so a retry can run fresh, then propagate.
+            logger.warning(
+                "exception inside intercepted handler for key=%r; releasing slot",
+                key,
+                exc_info=True,
+            )
             await self.store.release(key)
             raise
 
-        if capturer.status is None or capturer.status >= self.FIRST_SERVER_ERROR_STATUS:
-            # 5xx (or no response at all) is treated as a transient failure.
-            # Don't cache it — drop the slot so a retry runs the handler again.
+        if interceptor.streamed:
+            # Streams can't be cached — see ``CachedResponse`` invariant.
+            await self.store.release(key)
+            return
+
+        if interceptor.status is None:
+            # Handler returned without emitting http.response.start —
+            # synthesize a 500 so the wire contract holds.
+            logger.warning(
+                "handler returned without sending http.response.start for key=%r; emitting 500",
+                key,
+            )
+            await self.store.release(key)
+            await self._send_plain_response(
+                send,
+                status=500,
+                message="upstream handler emitted no response",
+                extra_headers=[(b"idempotency-stored", b"false")],
+            )
+            return
+
+        if interceptor.status >= self.FIRST_SERVER_ERROR_STATUS:
+            # 5xx is transient — drop the slot so a retry runs fresh.
             await self.store.release(key)
             await self._send_response(
                 send,
-                status=capturer.status or 0,
-                headers=list(capturer.headers),
-                body=bytes(capturer.body),
+                status=interceptor.status,
+                headers=list(interceptor.headers),
+                body=bytes(interceptor.body),
             )
             return
 
         cached = CachedResponse(
-            status_code=capturer.status,
-            headers=capturer.headers,
-            body=bytes(capturer.body),
+            status_code=interceptor.status,
+            headers=interceptor.headers,
+            body=bytes(interceptor.body),
         )
         extra_headers: list[tuple[bytes, bytes]] = []
         try:
             await self.store.complete(key, cached, ttl=self.completed_ttl)
         except StoreError:
-            # Per the deferred decision in issue #3: the request itself
-            # succeeded; surface the storage failure to the client via a
-            # header so retries know they won't replay.
             logger.warning(
                 "store.complete raised StoreError for key=%r; serving "
                 "uncached response with Idempotency-Stored: false",
@@ -199,9 +219,9 @@ class IdempotencyMiddleware:
 
         await self._send_response(
             send,
-            status=capturer.status,
-            headers=[*capturer.headers, *extra_headers],
-            body=bytes(capturer.body),
+            status=interceptor.status,
+            headers=[*interceptor.headers, *extra_headers],
+            body=bytes(interceptor.body),
         )
 
     def _extract_key(self, scope: Scope) -> str | None:
@@ -272,37 +292,72 @@ class IdempotencyMiddleware:
         *,
         status: int,
         message: str,
+        extra_headers: list[tuple[bytes, bytes]] | None = None,
     ) -> None:
         """Send a plain-text response with the given status and message body."""
         body = message.encode("utf-8")
+        headers: list[tuple[bytes, bytes]] = [
+            (b"content-type", b"text/plain; charset=utf-8"),
+            (b"content-length", str(len(body)).encode("ascii")),
+        ]
+        if extra_headers:
+            headers.extend(extra_headers)
         await self._send_response(
             send,
             status=status,
-            headers=[
-                (b"content-type", b"text/plain; charset=utf-8"),
-                (b"content-length", str(len(body)).encode("ascii")),
-            ],
+            headers=headers,
             body=body,
         )
 
 
-class _ResponseCapturer:
-    """Buffers status, headers, and body emitted by the wrapped app.
+class _ResponseInterceptor:
+    """Buffers a non-streaming response or forwards a streaming one live.
 
-    The middleware emits the captured response to its own ``send`` after
-    it has decided whether to ``complete`` or ``release`` the slot —
-    that lets it amend headers (e.g., ``Idempotency-Stored: false``)
-    based on the storage outcome.
+    See ``docs/DESIGN.md`` ("Streaming response pass-through") for the
+    deferred-start mechanism and the rationale for reusing
+    ``Idempotency-Stored: false`` on streamed responses.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, send: Send) -> None:
+        self._send = send
         self.status: int | None = None
         self.headers: tuple[tuple[bytes, bytes], ...] = ()
         self.body = bytearray()
+        self.streamed = False
+        self._pending_start: Message | None = None
 
     async def __call__(self, message: Message) -> None:
+        if self.streamed:
+            await self._send(message)
+            return
+
         if message["type"] == "http.response.start":
+            if self._pending_start is not None:
+                msg = "ASGI protocol violation: duplicate http.response.start"
+                raise RuntimeError(msg)
+            self._pending_start = message
             self.status = message["status"]
             self.headers = tuple(message.get("headers", []))
-        elif message["type"] == "http.response.body":
+            return
+
+        if message["type"] == "http.response.body":
+            more_body = message.get("more_body", False)
+            if more_body:
+                if self._pending_start is None:
+                    # Typed raise (not assert) so it survives ``python -O``.
+                    msg = "ASGI protocol violation: http.response.body before http.response.start"
+                    raise RuntimeError(msg)
+                patched_start: Message = dict(self._pending_start)
+                patched_headers = list(patched_start.get("headers", []))
+                patched_headers.append((b"idempotency-stored", b"false"))
+                patched_start["headers"] = patched_headers
+
+                self.streamed = True
+                self._pending_start = None
+                await self._send(patched_start)
+                await self._send(message)
+                return
+
+            # Cleared so the duplicate-start guard stays load-bearing.
+            self._pending_start = None
             self.body.extend(message.get("body", b""))

--- a/src/fastapi_idempotency/types.py
+++ b/src/fastapi_idempotency/types.py
@@ -33,6 +33,17 @@ class AcquireOutcome(str, Enum):
 
 @dataclass(frozen=True, slots=True)
 class CachedResponse:
+    """A complete, single-frame HTTP response captured for replay.
+
+    **Invariant: cached responses are never streams.** Streaming
+    responses (those emitting ``http.response.body`` with
+    ``more_body=True``) are forwarded live by the middleware and
+    never reach ``Store.complete`` — see
+    ``docs/DESIGN.md`` ("Streaming response pass-through"). REPLAY
+    paths can therefore emit a ``CachedResponse`` as a single
+    start+body frame without per-record streaming logic.
+    """
+
     status_code: int
     headers: tuple[tuple[bytes, bytes], ...]
     body: bytes

--- a/tests/test_body_buffer.py
+++ b/tests/test_body_buffer.py
@@ -103,15 +103,26 @@ async def test_max_bytes_at_exactly_the_limit_passes() -> None:
     assert len(body) == 100
 
 
-async def test_replay_raises_on_double_consume() -> None:
+async def test_replay_yields_body_once_then_forwards_to_original_receive() -> None:
+    """``_Replay`` is no longer one-shot: subsequent calls fall through to
+    the original ``receive`` so disconnect-listening (e.g. from
+    Starlette's ``StreamingResponse``) still observes ``http.disconnect``.
+    """
     receive = make_receive(
-        [{"type": "http.request", "body": b"x", "more_body": False}],
+        [
+            {"type": "http.request", "body": b"x", "more_body": False},
+            # The original ``receive`` would normally block until disconnect;
+            # we feed an explicit disconnect to assert forwarding works.
+            {"type": "http.disconnect"},
+        ],
     )
     _, replay = await buffer_request_body(receive)
 
-    await replay()
-    with pytest.raises(RuntimeError):
-        await replay()
+    first = await replay()
+    assert first == {"type": "http.request", "body": b"x", "more_body": False}
+
+    second = await replay()
+    assert second == {"type": "http.disconnect"}
 
 
 async def test_disconnect_mid_stream_returns_partial_body() -> None:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,438 @@
+"""Streaming response pass-through.
+
+Unit tests probe ``_ResponseInterceptor`` with a recorder ``send``;
+integration tests drive ``IdempotencyMiddleware`` end-to-end via
+httpx ASGITransport. See ``docs/DESIGN.md`` for the design rationale.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import StreamingResponse
+from starlette.routing import Route
+
+from fastapi_idempotency import (
+    IdempotencyKey,
+    IdempotencyMiddleware,
+    InMemoryStore,
+)
+from fastapi_idempotency.middleware import _ResponseInterceptor
+
+if TYPE_CHECKING:
+    from starlette.types import Message, Receive, Scope, Send
+
+
+# Unit: ``_ResponseInterceptor``  ----------------------------------------------
+
+
+class _SendRecorder:
+    """Mock ASGI send: appends every message to ``messages`` for assertions."""
+
+    def __init__(self) -> None:
+        self.messages: list[Message] = []
+
+    async def __call__(self, message: Message) -> None:
+        self.messages.append(message)
+
+
+async def test_interceptor_buffers_single_chunk_response_without_forwarding() -> None:
+    """Non-streaming: nothing forwarded; status/headers/body buffered."""
+    recorder = _SendRecorder()
+    interceptor = _ResponseInterceptor(recorder)
+
+    await interceptor({"type": "http.response.start", "status": 200, "headers": [(b"x", b"y")]})
+    await interceptor({"type": "http.response.body", "body": b"hello", "more_body": False})
+
+    assert recorder.messages == []  # buffered, not forwarded
+    assert interceptor.streamed is False
+    assert interceptor.status == 200
+    assert interceptor.headers == ((b"x", b"y"),)
+    assert bytes(interceptor.body) == b"hello"
+
+
+async def test_interceptor_treats_missing_more_body_as_non_streaming() -> None:
+    """ASGI default: ``more_body`` absent ⇒ ``False``. Stay in buffered mode."""
+    recorder = _SendRecorder()
+    interceptor = _ResponseInterceptor(recorder)
+
+    await interceptor({"type": "http.response.start", "status": 200, "headers": []})
+    await interceptor({"type": "http.response.body", "body": b"x"})  # no more_body key
+
+    assert recorder.messages == []
+    assert interceptor.streamed is False
+    assert bytes(interceptor.body) == b"x"
+
+
+async def test_interceptor_forwards_streaming_response_with_idempotency_stored_header() -> None:
+    """First chunk has ``more_body=True`` → flip to forwarding mode.
+
+    Patched ``http.response.start`` carries ``Idempotency-Stored: false``;
+    every body chunk is forwarded live (none buffered into ``self.body``).
+    """
+    recorder = _SendRecorder()
+    interceptor = _ResponseInterceptor(recorder)
+
+    await interceptor(
+        {"type": "http.response.start", "status": 200, "headers": [(b"x-trace", b"t1")]},
+    )
+    await interceptor({"type": "http.response.body", "body": b"chunk1", "more_body": True})
+    await interceptor({"type": "http.response.body", "body": b"chunk2", "more_body": True})
+    await interceptor({"type": "http.response.body", "body": b"chunk3", "more_body": False})
+
+    assert interceptor.streamed is True
+    # Memory invariant: streaming must not buffer body bytes.
+    assert len(interceptor.body) == 0
+
+    # Recorder saw 4 messages: patched start, then 3 chunks verbatim.
+    assert len(recorder.messages) == 4
+    start = recorder.messages[0]
+    assert start["type"] == "http.response.start"
+    assert start["status"] == 200
+    assert (b"idempotency-stored", b"false") in start["headers"]
+    # Original headers preserved alongside the patch.
+    assert (b"x-trace", b"t1") in start["headers"]
+    # Body chunks forwarded unmodified.
+    assert recorder.messages[1] == {
+        "type": "http.response.body",
+        "body": b"chunk1",
+        "more_body": True,
+    }
+    assert recorder.messages[2]["body"] == b"chunk2"
+    assert recorder.messages[3]["body"] == b"chunk3"
+    assert recorder.messages[3]["more_body"] is False
+
+
+async def test_interceptor_raises_on_body_before_start() -> None:
+    """ASGI protocol violation: body without prior start is ``RuntimeError``,
+    not ``AssertionError`` — production-grade so ``python -O`` still raises."""
+    recorder = _SendRecorder()
+    interceptor = _ResponseInterceptor(recorder)
+
+    with pytest.raises(RuntimeError, match=r"http\.response\.body before"):
+        await interceptor({"type": "http.response.body", "body": b"x", "more_body": True})
+
+
+async def test_interceptor_raises_on_duplicate_start() -> None:
+    """ASGI protocol violation: two ``http.response.start`` messages — raise
+    rather than silently overwrite the captured status/headers."""
+    recorder = _SendRecorder()
+    interceptor = _ResponseInterceptor(recorder)
+
+    await interceptor({"type": "http.response.start", "status": 200, "headers": []})
+    with pytest.raises(RuntimeError, match=r"duplicate http\.response\.start"):
+        await interceptor({"type": "http.response.start", "status": 200, "headers": []})
+
+
+async def test_interceptor_does_not_mutate_original_start_message() -> None:
+    """We patch via ``dict(...)`` copy; the caller's start message stays intact.
+
+    Defends against a future maintainer dropping the copy and accidentally
+    leaking the ``Idempotency-Stored`` header into the app's own state.
+    """
+    recorder = _SendRecorder()
+    interceptor = _ResponseInterceptor(recorder)
+    original_start: Message = {
+        "type": "http.response.start",
+        "status": 200,
+        "headers": [(b"a", b"b")],
+    }
+
+    await interceptor(original_start)
+    await interceptor({"type": "http.response.body", "body": b"x", "more_body": True})
+
+    assert original_start["headers"] == [(b"a", b"b")]
+
+
+# Integration: streaming pass-through end-to-end  ---------------------------
+
+
+async def _drive_request_lifecycle(receive: Receive) -> None:
+    """Drain ``http.request`` messages until the body is fully read."""
+    while True:
+        message = await receive()
+        if message["type"] != "http.request":
+            break
+        if not message.get("more_body", False):
+            break
+
+
+def _make_streaming_app(chunks: list[bytes]) -> Any:
+    """ASGI app that emits ``chunks`` as a streaming response.
+
+    Each chunk goes out as its own ``http.response.body`` message;
+    every chunk except the last has ``more_body=True``. Mirrors what
+    Starlette's ``StreamingResponse`` does on the wire.
+    """
+
+    async def app(_scope: Scope, receive: Receive, send: Send) -> None:
+        await _drive_request_lifecycle(receive)
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/event-stream")],
+            },
+        )
+        for i, chunk in enumerate(chunks):
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": chunk,
+                    "more_body": i < len(chunks) - 1,
+                },
+            )
+
+    return app
+
+
+async def test_streaming_response_flows_through_with_stored_false_header() -> None:
+    chunks = [b"first ", b"second ", b"third"]
+    middleware = IdempotencyMiddleware(_make_streaming_app(chunks), InMemoryStore())
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/",
+            headers={"Idempotency-Key": "stream-1"},
+            content=b"req",
+        )
+
+    assert response.status_code == 200
+    assert response.content == b"first second third"
+    assert response.headers.get("idempotency-stored") == "false"
+
+
+async def test_streaming_response_releases_slot_so_retry_runs_handler_again() -> None:
+    """A stream can't be replayed — the second request must run the handler."""
+    invocations = 0
+
+    async def streaming_app(_scope: Scope, receive: Receive, send: Send) -> None:
+        nonlocal invocations
+        await _drive_request_lifecycle(receive)
+        invocations += 1
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            },
+        )
+        await send({"type": "http.response.body", "body": b"a", "more_body": True})
+        await send({"type": "http.response.body", "body": b"b", "more_body": False})
+
+    store = InMemoryStore()
+    middleware = IdempotencyMiddleware(streaming_app, store)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        first = await client.post(
+            "/",
+            headers={"Idempotency-Key": "k"},
+            content=b"x",
+        )
+        second = await client.post(
+            "/",
+            headers={"Idempotency-Key": "k"},
+            content=b"x",
+        )
+
+    assert first.status_code == 200
+    assert first.headers.get("idempotency-stored") == "false"
+    assert second.status_code == 200
+    assert second.headers.get("idempotent-replayed") is None  # not a replay
+    assert second.headers.get("idempotency-stored") == "false"  # also a stream
+    assert invocations == 2
+    assert await store.get(IdempotencyKey("k")) is None
+
+
+async def test_non_streaming_response_still_caches_and_replays() -> None:
+    """Single-chunk responses keep the v0.1.0 contract: caching + replay header."""
+    invocations = 0
+
+    async def single_chunk_app(scope: Scope, receive: Receive, send: Send) -> None:
+        nonlocal invocations
+        await _drive_request_lifecycle(receive)
+        invocations += 1
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 201,
+                "headers": [(b"content-type", b"application/json")],
+            },
+        )
+        await send(
+            {"type": "http.response.body", "body": b'{"ok":true}', "more_body": False},
+        )
+
+    middleware = IdempotencyMiddleware(single_chunk_app, InMemoryStore())
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        first = await client.post(
+            "/",
+            headers={"Idempotency-Key": "k2"},
+            content=b"x",
+        )
+        second = await client.post(
+            "/",
+            headers={"Idempotency-Key": "k2"},
+            content=b"x",
+        )
+
+    assert first.status_code == 201
+    assert first.headers.get("idempotency-stored") is None
+    assert first.headers.get("idempotent-replayed") is None
+    assert second.status_code == 201
+    assert second.content == first.content
+    assert second.headers.get("idempotent-replayed") == "true"
+    assert invocations == 1
+
+
+async def test_streaming_app_raises_mid_stream_releases_slot() -> None:
+    """If the app crashes after emitting start + first chunk, the slot must
+    be released so a retry runs the handler again. The client sees a
+    truncated stream, but ``Idempotency-Key`` semantics survive."""
+    invocations = 0
+
+    async def flaky_streaming_app(_scope: Scope, receive: Receive, send: Send) -> None:
+        nonlocal invocations
+        await _drive_request_lifecycle(receive)
+        invocations += 1
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            },
+        )
+        await send({"type": "http.response.body", "body": b"a", "more_body": True})
+        if invocations == 1:
+            msg = "boom"
+            raise RuntimeError(msg)
+        await send({"type": "http.response.body", "body": b"b", "more_body": False})
+
+    store = InMemoryStore()
+    middleware = IdempotencyMiddleware(flaky_streaming_app, store)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        # httpx surfaces the mid-stream raise as a protocol error or as
+        # the underlying RuntimeError depending on transport buffering.
+        # Partial-body wire delivery is pinned at the unit level.
+        with pytest.raises((httpx.RemoteProtocolError, RuntimeError)):
+            await client.post(
+                "/",
+                headers={"Idempotency-Key": "k-flaky"},
+                content=b"x",
+            )
+
+        assert await store.get(IdempotencyKey("k-flaky")) is None
+
+        second = await client.post(
+            "/",
+            headers={"Idempotency-Key": "k-flaky"},
+            content=b"x",
+        )
+
+    assert second.status_code == 200
+    assert second.headers.get("idempotency-stored") == "false"  # still a stream
+    assert invocations == 2
+
+
+async def test_handler_returns_without_emitting_start_yields_500() -> None:
+    """Handler never sends ``http.response.start`` — middleware synthesizes
+    a 500 with ``Idempotency-Stored: false`` and releases the slot."""
+
+    async def silent_app(_scope: Scope, receive: Receive, _send: Send) -> None:
+        await _drive_request_lifecycle(receive)
+
+    store = InMemoryStore()
+    middleware = IdempotencyMiddleware(silent_app, store)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/",
+            headers={"Idempotency-Key": "k-silent"},
+            content=b"x",
+        )
+
+    assert response.status_code == 500
+    assert response.headers.get("idempotency-stored") == "false"
+    assert await store.get(IdempotencyKey("k-silent")) is None
+
+
+async def test_streaming_with_empty_body_first_chunk_still_detected() -> None:
+    """``more_body=True`` on an empty first chunk still triggers forwarding mode.
+
+    Defensive: an app that opens the stream eagerly (e.g., for back-pressure
+    headers) before producing data should still pass through.
+    """
+    middleware = IdempotencyMiddleware(
+        _make_streaming_app([b"", b"data"]),
+        InMemoryStore(),
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/",
+            headers={"Idempotency-Key": "k3"},
+            content=b"x",
+        )
+
+    assert response.status_code == 200
+    assert response.content == b"data"
+    assert response.headers.get("idempotency-stored") == "false"
+
+
+# Framework smoke: Starlette's ``StreamingResponse``  -----------------------
+#
+# Starlette is a hard runtime dep, so we don't pay a new test
+# dependency to verify the canonical streaming primitive on the wire.
+# FastAPI's ``StreamingResponse`` re-exports Starlette's, so this also
+# covers the FastAPI path implicitly.
+
+
+async def test_starlette_streaming_response_passes_through() -> None:
+    async def chunk_iter() -> Any:
+        yield b"a"
+        yield b"b"
+        yield b"c"
+
+    async def stream_endpoint(_request: Any) -> StreamingResponse:
+        return StreamingResponse(chunk_iter(), media_type="text/event-stream")
+
+    app = Starlette(
+        routes=[Route("/stream", stream_endpoint, methods=["POST"])],
+    )
+    middleware = IdempotencyMiddleware(app, InMemoryStore())
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/stream",
+            headers={"Idempotency-Key": "starlette-stream"},
+            content=b"req",
+        )
+
+    assert response.status_code == 200
+    assert response.content == b"abc"
+    assert response.headers.get("idempotency-stored") == "false"


### PR DESCRIPTION
Closes #18

## Summary

Streaming responses (`StreamingResponse`, SSE feeds, file downloads) now flow through the middleware live instead of being buffered into memory — buffering would either OOM the worker or hold the first byte until the stream completes, defeating the point of streaming.

- **`_ResponseInterceptor`** (renamed from `_ResponseCapturer`) defers `http.response.start` until the first body chunk so the streaming signal (`more_body=True`) can be detected. On detection it patches start with `Idempotency-Stored: false` and forwards every message live; the slot is released after the app returns. Single-chunk responses keep the v0.1.0 buffered/cached path. Detection mechanism + invariants documented in `docs/DESIGN.md`.
- **`Idempotency-Stored: false`** is now a documented union signal — it appears on streaming pass-through, `StoreError` storage failure, and the synthesized 500 when the handler emits no response. In every case it means "this response will not replay on retry; the slot is gone."
- **Hardening on the side** (caught during review): `_ResponseInterceptor` raises typed `RuntimeError` (not bare `assert` — survives `python -O`) on ASGI protocol violations (duplicate `http.response.start`, body-before-start). The handler-emits-no-response path was also fixed: it used to send `status=0` (itself a protocol violation); now it logs and emits a synthetic 500 with `Idempotency-Stored: false`.
- **`_Replay` bug** (in `body_buffer.py`) found and fixed: the buffered-request replay was one-shot, but Starlette's `StreamingResponse` starts a background `receive()` task to listen for `http.disconnect` after body consumption. The one-shot replay crashed that task. `_Replay` now forwards subsequent calls to the original `receive`.
- **`CachedResponse` invariant**: docstring states "cached responses are never streams" — load-bearing because REPLAY emits cached records as a single buffered frame.

## Test plan

- [x] `pytest -m "not redis"` — InMemory + middleware path, 116 passed locally
- [x] `REDIS_URL=redis://localhost:6379 REDIS_TESTS_REQUIRED=1 pytest --cov` — full suite + coverage gate, 141 passed locally, total coverage 95.63%
- [x] CI matrix passes coverage gate on all 4 Python versions (3.10/3.11/3.12/3.13)
- [x] FastAPI / Starlette `StreamingResponse` works end-to-end (covered by `test_starlette_streaming_response_passes_through`)
- [x] Mid-stream raise releases the slot (covered by `test_streaming_app_raises_mid_stream_releases_slot`)
- [x] No-response handler synthesizes 500 with `Idempotency-Stored: false` (covered by `test_handler_returns_without_emitting_start_yields_500`)
- [x] Memory invariant: streaming does not buffer body bytes (covered by `len(interceptor.body) == 0` assertion in unit tests)