### PR TITLE
chore(comments): trim verbose comments, drop issue/slice refs

### DIFF
--- a/src/fastapi_idempotency/__init__.py
+++ b/src/fastapi_idempotency/__init__.py
@@ -1,22 +1,13 @@
 """fastapi-idempotency: ``Idempotency-Key`` middleware for FastAPI / Starlette.
 
-Public API (the names listed in ``__all__``) is what most users need:
-the middleware, the in-memory store, ``RedisStore`` (requires the
-``[redis]`` extra), the ``Store`` Protocol for custom backends, and
-the exception hierarchy for catch blocks.
+Public API is the names listed in ``__all__``. Store-implementation
+types (``AcquireOutcome``, ``AcquireResult``, ``IdempotencyRecord``,
+``IdempotencyState``, ``CachedResponse``, ``IdempotencyKey``,
+``Fingerprint``) are importable for users writing custom ``Store``
+implementations but kept out of ``__all__`` as advanced surface.
 
-Store-implementation details (``AcquireOutcome``, ``AcquireResult``,
-``IdempotencyRecord``, ``IdempotencyState``, ``CachedResponse``,
-``IdempotencyKey``, ``Fingerprint``) are still importable from this
-module for users writing custom ``Store`` implementations, but are kept
-out of ``__all__`` to signal that they are advanced surface — not what
-a typical caller reaches for.
-
-``RedisStore`` is loaded lazily via :pep:`562` ``__getattr__`` so that
-``import fastapi_idempotency`` keeps working without the ``[redis]``
-extra installed — accessing ``fastapi_idempotency.RedisStore`` is what
-triggers the import (and the helpful ``ImportError`` from
-``stores.redis`` if the extra is missing).
+``RedisStore`` is loaded lazily via :pep:`562` ``__getattr__`` so
+``import fastapi_idempotency`` works without the ``[redis]`` extra.
 """
 
 from __future__ import annotations
@@ -44,9 +35,7 @@ from .types import (
 )
 
 if TYPE_CHECKING:
-    # Static-checker re-export so ``from fastapi_idempotency import RedisStore``
-    # type-checks without forcing an import at module load (which would fail
-    # for users who installed the package without the ``[redis]`` extra).
+    # Static-checker re-export — runtime import is lazy via __getattr__.
     from .stores.redis import RedisStore as RedisStore
 
 __version__ = "0.1.0"
@@ -66,17 +55,8 @@ __all__ = [
 
 
 def __getattr__(name: str) -> Any:
-    """PEP 562 lazy attribute access.
-
-    Defers importing ``RedisStore`` (and the optional ``redis`` extra
-    it depends on) until the user actually references it. Without this,
-    ``import fastapi_idempotency`` would fail on installations that
-    lack the ``[redis]`` extra — even for users who only use
-    ``InMemoryStore``.
-    """
+    """PEP 562 lazy attribute access — defers redis-py until first use."""
     if name == "RedisStore":
-        # Lazy import is the whole point: deferring redis-py until access
-        # lets users without the [redis] extra still `import fastapi_idempotency`.
         from .stores.redis import RedisStore  # noqa: PLC0415
 
         return RedisStore

--- a/src/fastapi_idempotency/body_buffer.py
+++ b/src/fastapi_idempotency/body_buffer.py
@@ -17,14 +17,12 @@ async def buffer_request_body(
 ) -> tuple[bytes, Receive]:
     """Drain ASGI ``receive()`` and return ``(body, replay_receive)``.
 
-    Middleware must fingerprint the body before the handler consumes it;
-    ``receive()`` is one-shot, so we drain and hand the handler a replay
-    that yields the same body once.
+    The middleware needs the body for fingerprinting; ``receive()`` is
+    one-shot, so we drain and hand the handler a replay.
 
-    Raises :class:`RequestTooLargeError` as soon as the running total
-    exceeds ``max_bytes``; the rest of the stream is left untouched so
-    the caller can decide what to do (typically respond 413 without
-    reading further).
+    Raises :class:`RequestTooLargeError` once the running total exceeds
+    ``max_bytes``; the rest of the stream is left untouched so the
+    caller can respond 413 without reading further.
     """
     chunks: list[bytes] = []
     total = 0

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -27,9 +27,8 @@ class IdempotencyMiddleware:
     """ASGI middleware enforcing ``Idempotency-Key`` semantics.
 
     Only non-safe methods (POST, PATCH, PUT, DELETE) are intercepted; safe
-    requests pass through untouched. Implemented as a raw ASGI class rather
-    than :class:`starlette.middleware.base.BaseHTTPMiddleware` so streaming
-    response pass-through (v0.2.0) remains possible.
+    requests pass through untouched. Built on raw ASGI rather than
+    ``BaseHTTPMiddleware`` so streaming responses can pass through live.
     """
 
     NON_SAFE_METHODS: ClassVar[frozenset[str]] = frozenset(
@@ -119,8 +118,7 @@ class IdempotencyMiddleware:
         if result.outcome is AcquireOutcome.REPLAY:
             cached = result.record.response
             if cached is None:
-                # Store contract says REPLAY → response is set; if we ever
-                # see this, it's a store bug. Treat as 500.
+                # Store-contract violation: REPLAY without a response.
                 await self._send_plain_response(
                     send,
                     status=500,
@@ -233,9 +231,8 @@ class IdempotencyMiddleware:
         return 1 <= len(value) <= self.MAX_KEY_LENGTH and value.isascii()
 
     def _content_length_exceeds_limit(self, scope: Scope) -> bool:
-        # Pre-check: if Content-Length declares a body bigger than the
-        # configured limit, skip idempotency entirely. We can't recover
-        # mid-buffer, so this header is the only fence we trust.
+        # Pre-check: we can't recover mid-buffer, so Content-Length is
+        # the only fence we trust before letting the request through.
         if self.max_body_bytes is None:
             return False
         raw = self._get_header(scope, b"content-length")
@@ -249,12 +246,7 @@ class IdempotencyMiddleware:
 
     @staticmethod
     def _get_header(scope: Scope, name: bytes) -> bytes | None:
-        """Return the first header matching ``name`` (case-insensitive).
-
-        ASGI delivers headers as a list of ``(bytes, bytes)`` tuples
-        with names lowercased by the server, but lower-casing both sides
-        keeps the helper safe regardless of the caller's input.
-        """
+        """Return the first header matching ``name`` (case-insensitive)."""
         target = name.lower()
         headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
         for header_name, header_value in headers:
@@ -358,6 +350,6 @@ class _ResponseInterceptor:
                 await self._send(message)
                 return
 
-            # Cleared so the duplicate-start guard stays load-bearing.
+            # Clear so a second http.response.start re-trips the guard.
             self._pending_start = None
             self.body.extend(message.get("body", b""))

--- a/src/fastapi_idempotency/store.py
+++ b/src/fastapi_idempotency/store.py
@@ -94,14 +94,12 @@ class Store(Protocol):
     async def release(self, key: IdempotencyKey) -> None:
         """Remove the slot for ``key``; no-op if no record exists.
 
-        This is the explicit-cleanup path used when the handler raised
-        or returned an uncached status (5xx, redirects, etc.). Idempotent
-        by design so the middleware's error path can call it
+        Idempotent by design so the middleware's error path can call it
         unconditionally — it races with ``in_flight_ttl`` expiry, and
         raising on a missing record would crash the error handler.
 
-        Process crashes are handled passively by ``in_flight_ttl``
-        expiring the orphaned slot; stores do not need a separate
-        recovery mechanism.
+        Process crashes never call ``release``; orphaned slots are
+        recovered passively via the in-flight TTL. Stores need no
+        separate recovery mechanism.
         """
         ...

--- a/src/fastapi_idempotency/stores/__init__.py
+++ b/src/fastapi_idempotency/stores/__init__.py
@@ -1,9 +1,8 @@
 """Concrete Store implementations.
 
-:class:`~fastapi_idempotency.stores.redis.RedisStore` is intentionally not
-re-exported from here: importing it requires the optional ``redis`` extra.
-Import it explicitly from :mod:`fastapi_idempotency.stores.redis` when you
-need it.
+``RedisStore`` is not re-exported here — it requires the optional
+``redis`` extra. Use ``from fastapi_idempotency import RedisStore`` (lazy
+via PEP 562) or import directly from ``fastapi_idempotency.stores.redis``.
 """
 
 from __future__ import annotations

--- a/src/fastapi_idempotency/stores/_serde.py
+++ b/src/fastapi_idempotency/stores/_serde.py
@@ -1,25 +1,13 @@
-"""Serialization/deserialization helpers for store-persisted records.
+"""Serialization helpers for store-persisted records.
 
-Records are serialized as msgpack-encoded envelopes with an explicit schema
-version, so the on-disk shape can evolve in future minor releases without
-breaking already-stored records. Read paths verify the envelope version,
-validate field types/ranges defensively, and raise :class:`StoreError` on
-any malformed input.
+Records are serialized as msgpack-encoded envelopes ``{"v": 1, "data":
+{...}}`` so the on-disk shape can evolve without breaking already-stored
+records. Read paths verify the envelope version, validate field
+types/ranges defensively, and raise :class:`StoreError` on any malformed
+input.
 
-Wire format::
-
-    {
-        "v": 1,                          # schema version
-        "data": { ... record fields ... }
-    }
-
-This module is private (underscore-prefixed) — its API is an implementation
-detail of the store backends, not part of the public package surface.
-
-Logging note: error paths populate ``logger.debug(..., extra={...})`` with
-``version`` and ``expected`` fields so structured loggers (Datadog, Loki,
-ELK with JSON formatters) can grep deploy-incident logs in seconds. The
-fallback message string also embeds the values for plain-formatter logs.
+Private module (underscore-prefixed) — implementation detail of the
+store backends.
 """
 
 from __future__ import annotations
@@ -42,38 +30,29 @@ from fastapi_idempotency.types import (
 logger = logging.getLogger(__name__)
 
 SCHEMA_VERSION = 1
-# TODO(v=2): introduce MIN_SUPPORTED_VERSION when adding a new schema version,
-# and switch to a decoder registry (`_DECODERS = {1: _v1, 2: _v2}`) so old
-# records remain readable during rolling deploys.
+# When introducing v=2: add MIN_SUPPORTED_VERSION and switch to a
+# decoder registry (`_DECODERS = {1: _v1, 2: _v2}`) so old records
+# remain readable during rolling deploys.
 
-# Unpack limits — sized to the v0.3.0 production max_body_bytes default
-# (1 MiB) plus envelope overhead and headroom. These caps prevent
-# memory-DoS via attacker-crafted oversized payloads.
+# Caps prevent memory-DoS via attacker-crafted oversized payloads.
 _MAX_BODY_BYTES = 1 * 1024 * 1024  # 1 MiB
 _MAX_BUFFER_SIZE = 2 * _MAX_BODY_BYTES  # body + envelope + headroom
 _MAX_BIN_LEN = _MAX_BODY_BYTES
-_MAX_STR_LEN = 8 * 1024  # 8 KiB — header values realistic limit
+_MAX_STR_LEN = 8 * 1024  # realistic upper bound on header values
 _MAX_ARRAY_LEN = 256  # max headers + safety margin
 _MAX_MAP_LEN = 16  # envelope + record fields
 _MAX_HEADERS = 100
 
-# HTTP status code valid range (inclusive lower, exclusive upper).
 _VALID_STATUS_RANGE = (100, 600)
-
-# Each header is a (name, value) pair — exactly 2 elements.
 _HEADER_PAIR_LEN = 2
-
-# Truncation length for exception repr in error messages — defends
-# against log-volume DoS via attacker-crafted multi-MB blob whose repr
-# would otherwise blow up log lines.
+# Truncate exception repr to defend against log-volume DoS.
 _EXC_REPR_LIMIT = 200
 
 
 def encode_record(record: IdempotencyRecord) -> bytes:
     """Serialize an :class:`IdempotencyRecord` to versioned msgpack bytes.
 
-    The resulting bytes are deterministic across calls (same input → same
-    bytes); see ``test_encode_is_deterministic`` for the pinned contract.
+    Deterministic: same input produces identical bytes.
     """
     envelope = {
         "v": SCHEMA_VERSION,
@@ -152,13 +131,12 @@ def _record_to_dict(record: IdempotencyRecord) -> dict[str, Any]:
 def _dict_to_record(d: dict[str, Any]) -> IdempotencyRecord:
     """Construct ``IdempotencyRecord`` from decoded dict.
 
-    Raises ``KeyError`` on missing fields, ``ValueError`` on invalid values,
-    ``TypeError`` on wrong types — all wrapped into ``StoreError`` by the
-    caller (:func:`decode_record`).
+    Raises ``KeyError`` / ``ValueError`` / ``TypeError`` — all wrapped
+    into ``StoreError`` by :func:`decode_record`.
     """
-    # NewType is a no-op at runtime — we validate each field explicitly to
-    # catch type-confusion attacks (e.g., key as int, body as str).
-
+    # Inputs come from Redis bytes (potentially corrupted/poisoned);
+    # NewType is erased at runtime, so explicit isinstance checks are
+    # the only defense against type-confusion (e.g., key as int).
     key_value = d["key"]
     if not isinstance(key_value, str):
         msg = f"key must be str, got {type(key_value).__name__}"
@@ -169,8 +147,8 @@ def _dict_to_record(d: dict[str, Any]) -> IdempotencyRecord:
         msg = f"fingerprint must be str, got {type(fingerprint_value).__name__}"
         raise TypeError(msg)
 
-    state_value = d["state"]  # KeyError if missing → wrapped by caller
-    state = IdempotencyState(state_value)  # ValueError if unknown → wrapped
+    state_value = d["state"]
+    state = IdempotencyState(state_value)
 
     created_at = d["created_at"]
     if not isinstance(created_at, (int, float)) or not math.isfinite(created_at):
@@ -205,15 +183,10 @@ def _response_to_dict(response: CachedResponse) -> dict[str, Any]:
 
 
 def _dict_to_response(d: dict[str, Any]) -> CachedResponse:
-    """Construct ``CachedResponse`` from decoded dict.
-
-    See :func:`_coerce_header_pairs` for the structural validation of
-    headers (arity + bytes-type — guards against ``bytes(int)``
-    memory-blow-up attacks).
-    """
+    """Construct ``CachedResponse`` from decoded dict."""
     status_code = d["status_code"]
+    # bool is a subclass of int — must be rejected explicitly.
     if not isinstance(status_code, int) or isinstance(status_code, bool):
-        # bool is subclass of int — explicit reject
         msg = f"status_code must be int, got {type(status_code).__name__}"
         raise TypeError(msg)
     if not (_VALID_STATUS_RANGE[0] <= status_code < _VALID_STATUS_RANGE[1]):
@@ -242,7 +215,7 @@ def _dict_to_response(d: dict[str, Any]) -> CachedResponse:
     return CachedResponse(
         status_code=status_code,
         headers=headers,
-        body=bytes(body),  # bytearray → bytes for immutability
+        body=bytes(body),  # ensure immutable bytes (input may be bytearray)
         media_type=media_type,
     )
 
@@ -252,11 +225,9 @@ def _coerce_header_pairs(
 ) -> tuple[tuple[bytes, bytes], ...]:
     """Validate and coerce a list of header pairs.
 
-    Each pair must be a 2-element list/tuple of bytes. Guards against:
-      * arity confusion (3-tuple sneaking through into iteration unpack);
-      * ``bytes(int)`` memory-blow-up — if a decoded value is an int,
-        ``bytes(N)`` allocates N null bytes, so a stored value of
-        ``2**30`` blows up to 1 GiB before any sanity check.
+    Each pair must be a 2-element list/tuple of bytes. The bytes-only
+    check guards against ``bytes(int)`` memory-blow-up — a stored int
+    of ``2**30`` would allocate 1 GiB before any sanity check.
     """
     result: list[tuple[bytes, bytes]] = []
     for pair in raw:

--- a/src/fastapi_idempotency/stores/memory.py
+++ b/src/fastapi_idempotency/stores/memory.py
@@ -79,15 +79,9 @@ class InMemoryStore:
         async with self._lock:
             now = time.time()
             existing = self._records.get(key)
-            # Treat expired-but-not-yet-purged records as gone — keeps
-            # InMemory in line with Redis (PEXPIRE evicts and the Lua
-            # complete script's EXISTS check raises). Without this guard
-            # InMemory silently overwrites an expired in-flight slot
-            # with a fresh COMPLETED record, masking the in_flight_ttl
-            # tuning bug operators are supposed to see.
-            #
-            # Must run inside ``self._lock`` — moving this check outside
-            # the critical section reintroduces a TOCTOU silent-overwrite.
+            # Expired-but-not-yet-purged records count as gone (matches
+            # Redis PEXPIRE eviction). Must run inside ``self._lock`` —
+            # outside, a TOCTOU race could silent-overwrite a fresh slot.
             if existing is None or existing.is_expired(now):
                 raise StoreError(
                     f"cannot complete unknown idempotency key: {key!r}",

--- a/src/fastapi_idempotency/stores/redis.py
+++ b/src/fastapi_idempotency/stores/redis.py
@@ -1,53 +1,20 @@
 """Redis-backed :class:`Store` implementation.
 
-Requires the ``redis`` extra::
+Requires the ``redis`` extra (``pip install fastapi-idempotency[redis]``).
 
-    pip install fastapi-idempotency[redis]
+Storage layout: one HASH per idempotency key at ``{namespace}:{key}``
+with fields ``fp`` / ``state`` / ``data`` (msgpack-encoded
+:class:`IdempotencyRecord`). TTL is server-side via ``PEXPIRE``.
+The Lua acquire script reads ``fp`` and ``state`` directly without
+parsing msgpack, keeping the critical section minimal.
 
-Storage layout: one HASH per idempotency key at ``{namespace}:{key}`` with
-fields ``fp`` (fingerprint hex string), ``state`` (enum value string), and
-``data`` (msgpack-encoded :class:`IdempotencyRecord`). The Lua acquire
-script reads ``fp`` and ``state`` directly without parsing msgpack,
-keeping the server-side critical section minimal. ``HMGET`` reads all
-three fields in one atomic snapshot, eliminating eviction-race holes
-between sequential ``HGET``\\s.
+The client must use ``decode_responses=False`` (the default); the
+codec operates on raw bytes. The caller owns client lifecycle. Tune
+``socket_timeout`` and use ``BlockingConnectionPool`` for production
+— see the Redis quickstart in ``README.md`` for a worked example.
 
-TTL is set via ``PEXPIRE`` on the key; Redis handles eviction. See
-``docs/DESIGN.md`` ("Time source for the Redis backend") for why
-``created_at``/``expires_at`` inside the record are Python-clock while
-TTL is Redis-clock.
-
-Operators monitoring TTL should query Redis ``PTTL`` directly rather
-than computing ``record.expires_at - time.time()`` — record fields are
-advisory metadata, not the eviction authority.
-
-The Lua script touches a single key, so it is safe under Redis Cluster
-routing (no cross-slot operations). ``register_script`` caches the
-script SHA1 locally; ``redis-py`` re-issues ``EVAL`` automatically on
-``NOSCRIPT`` (e.g. after ``SCRIPT FLUSH`` or replica failover).
-
-The caller owns the :class:`redis.asyncio.Redis` client lifecycle — we
-do not close it. The client must be constructed with
-``decode_responses=False`` (the default); the codec operates on raw
-bytes and a ``decode_responses=True`` client will silently corrupt
-msgpack payloads.
-
-Recommended production client configuration::
-
-    import redis.asyncio
-    client = redis.asyncio.Redis(
-        connection_pool=redis.asyncio.BlockingConnectionPool(
-            max_connections=200,    # tune per RPS x p99 latency
-            timeout=2.0,            # bound queue wait on saturation
-        ),
-        socket_timeout=1.0,         # bound stalled-Redis cascades
-        socket_connect_timeout=1.0,
-    )
-
-Without ``socket_timeout`` an unhealthy Redis blocks ``acquire``
-indefinitely; without ``BlockingConnectionPool`` a stalled Redis
-exhausts the default 50-connection pool and surfaces as raw
-``ConnectionError``.
+See ``docs/DESIGN.md`` ("Time source for the Redis backend") for the
+TTL/clock split and cluster-routing notes.
 """
 
 from __future__ import annotations
@@ -87,29 +54,20 @@ logger = logging.getLogger(__name__)
 
 
 def _wrap_redis_error(op: str, exc: BaseException) -> StoreError:
-    """Wrap a redis-py exception as :class:`StoreError`.
-
-    Logs at DEBUG so operators flipping to debug level get a breadcrumb
-    before the StoreError bubbles up to the middleware. Truncated repr
-    defends against log-volume DoS via attacker-crafted multi-MB exception
-    text.
-    """
+    """Wrap a redis-py exception as :class:`StoreError`."""
+    # Truncated repr defends against log-volume DoS via attacker-crafted
+    # multi-MB exception text.
     logger.debug("redis %s failed: %r", op, exc)
     msg = f"Redis {op} failed: {repr(exc)[:200]}"
     return StoreError(msg)
 
 
-# Atomic acquire as a single Lua call — classifies into one of four
-# AcquireOutcome branches in one round-trip. Returns a 2-element table:
-# the outcome value (matches AcquireOutcome.<m>.value strings) and the
-# record's msgpack bytes (newly inserted or existing, depending on branch).
-#
-# HMGET reads all three fields in one atomic snapshot — closes the
-# eviction-race window where sequential HGETs could see a partially
-# evicted key (state=False, falling through to REPLAY with garbage data).
+# Single HMGET (not sequential HGETs) snapshots fp/state/data in one
+# atomic read so a concurrent HSET can't interleave between fields.
 #
 #   KEYS: [1] full namespaced key
 #   ARGV: [1] fingerprint hex, [2] ttl_ms (positive int), [3] new-record msgpack bytes
+#   Returns: 2-element table {outcome_string, record_msgpack}
 _ACQUIRE_LUA = """
 local key = KEYS[1]
 local fp = ARGV[1]
@@ -143,13 +101,10 @@ return {'replay', existing_data}
 """
 
 
-# Atomic complete: validates the slot still exists (TTL race may have
-# evicted it between Python's read and this script), then writes the new
-# state + data and refreshes TTL to ``completed_ttl``. Returns 'ok' on
-# success, ``redis.error_reply`` if the slot is gone.
-#
 #   KEYS: [1] full namespaced key
 #   ARGV: [1] new-record msgpack bytes, [2] ttl_ms (positive int)
+#   Returns: 'ok', or error_reply if the slot was evicted between
+#   Python's read and this call.
 _COMPLETE_LUA = """
 local key = KEYS[1]
 local data = ARGV[1]
@@ -180,7 +135,6 @@ class RedisStore:
     """
 
     def __init__(self, client: Redis, *, namespace: str = "idem") -> None:
-        # redis-py's get_encoder() is untyped in stubs as of 5.x.
         encoder = client.get_encoder()  # type: ignore[no-untyped-call]
         if encoder.decode_responses:
             msg = (
@@ -190,6 +144,8 @@ class RedisStore:
             raise ValueError(msg)
         self.client = client
         self.namespace = namespace
+        # ``register_script`` caches the SHA1 locally; redis-py re-issues
+        # ``EVAL`` automatically on ``NOSCRIPT`` (replica failover, SCRIPT FLUSH).
         self._acquire_script: Any = client.register_script(_ACQUIRE_LUA)
         self._complete_script: Any = client.register_script(_COMPLETE_LUA)
 
@@ -199,9 +155,8 @@ class RedisStore:
         fingerprint: Fingerprint,
         ttl: float,
     ) -> AcquireResult:
-        # Build the record we'd insert if CREATED. For other branches the
-        # Lua script returns the existing record's bytes and this serialized
-        # blob is discarded — accepted simplicity-tax for a single-script API.
+        # Pre-encode the would-be-CREATED record; non-CREATED branches
+        # discard it. Single-script trade-off.
         now = time.time()
         new_record = IdempotencyRecord(
             key=key,
@@ -247,10 +202,8 @@ class RedisStore:
             return None
 
         record = decode_record(data)
-        # Symmetry with InMemoryStore: filter expired records Python-side.
-        # Defense in depth — Redis PEXPIRE is the primary eviction path,
-        # but a millisecond-scale race between expiry and our read can
-        # surface a record that is already expired by client-side clock.
+        # Defense in depth: catch the sub-millisecond race between
+        # PEXPIRE and HGET via Python clock.
         if record.is_expired(time.time()):
             return None
         return record
@@ -261,15 +214,12 @@ class RedisStore:
         response: CachedResponse,
         ttl: float,
     ) -> None:
-        # NOTE: this is a 2-RTT operation (HGET + Lua). Between the read and
-        # the script call, a TTL eviction + re-acquire could create a fresh
-        # slot at the same key — we'd then complete-overwrite that fresh
-        # slot's data. Matches InMemoryStore behavior (caller-owns-slot
-        # contract; race bounded by in_flight_ttl tuning). Tracked for both
-        # backends in a v0.3.0+ hardening pass.
+        # 2-RTT (HGET + Lua): a TTL eviction + re-acquire between them
+        # would let us complete-overwrite a fresh slot's data. Bounded
+        # by in_flight_ttl tuning; harden in a future pass.
         full_key = self._key(key)
 
-        # Read existing to preserve identity (key, fingerprint, created_at).
+        # Read to preserve identity (key, fingerprint, created_at).
         try:
             existing_data = await self.client.hget(full_key, "data")  # type: ignore[misc]
         except (RedisError, OSError) as exc:
@@ -280,10 +230,8 @@ class RedisStore:
             raise StoreError(msg)
 
         existing = decode_record(existing_data)
-        # Defense in depth, symmetric with ``get``: PEXPIRE may not have
-        # fired yet on a sub-millisecond race, but the Python clock can
-        # already see ``expires_at`` elapsed. Treat that as gone (matches
-        # InMemoryStore's complete-on-expired guard from issue #17 / slice 7).
+        # Same Python-clock guard as ``get``: PEXPIRE may not have
+        # fired yet on a sub-millisecond race.
         now = time.time()
         if existing.is_expired(now):
             msg = f"cannot complete unknown idempotency key: {key!r}"

--- a/src/fastapi_idempotency/types.py
+++ b/src/fastapi_idempotency/types.py
@@ -60,12 +60,7 @@ class IdempotencyRecord:
     response: CachedResponse | None = None
 
     def is_expired(self, now: float) -> bool:
-        """Whether ``expires_at`` has elapsed as of ``now``.
-
-        The clock is injected so the domain stays free of
-        ``time.time`` / ``time.monotonic`` calls; stores pass whichever
-        source they use for TTL math.
-        """
+        """Whether ``expires_at`` has elapsed as of injected ``now``."""
         return self.expires_at <= now
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,8 @@ with a per-test ``FLUSHDB`` for isolation.
 If Docker is not available, ``redis_url`` skips dependent tests with a
 clear message rather than failing — local development without Docker is
 supported. In CI, set ``REDIS_TESTS_REQUIRED=1`` to convert the skip
-into a hard failure (slice 8 will export this in the redis job, so
-"Docker missing in CI" doesn't masquerade as a green build).
+into a hard failure so a missing-Docker CI doesn't masquerade as a
+green build.
 
 Set ``REDIS_URL`` to bypass the testcontainer entirely and point at an
 already-running Redis (e.g. a CI service container, or a local

--- a/tests/test_stores_conformance.py
+++ b/tests/test_stores_conformance.py
@@ -302,12 +302,7 @@ async def test_get_returns_none_after_ttl_expires(store: Store) -> None:
 
 @pytest.mark.slow
 async def test_acquire_after_ttl_expires_creates_fresh_slot(store: Store) -> None:
-    """Expired slots are reclaimed by the next ``acquire`` (lazy GC).
-
-    Closes the conformance gap from slice 5: the negative-TTL trick
-    (``ttl=-1.0``) is InMemory-only, so this expired-record reclaim
-    behavior couldn't be tested portably until a real wait was added.
-    """
+    """Expired slots are reclaimed by the next ``acquire`` (lazy GC)."""
     await store.acquire(KEY, FP, ttl=_TTL_S)
     await asyncio.sleep(_TTL_WAIT_S)
 

--- a/tests/test_stores_memory.py
+++ b/tests/test_stores_memory.py
@@ -1,12 +1,10 @@
 """InMemoryStore-specific tests.
 
 Behavioral conformance against the :class:`Store` protocol lives in
-``tests/test_stores_conformance.py`` (parametrized over both backends);
-that file also covers single-process concurrency. This file holds
-tests that exercise InMemory-only mechanics — specifically the
-negative-``ttl`` shortcut for expired records, which RedisStore's Lua
-``acquire`` rejects (``ttl_ms <= 0``) by design. Slice 7 (issue #17)
-will add real-time TTL tests covering both backends.
+``tests/test_stores_conformance.py`` (parametrized over both backends).
+This file holds tests that exercise InMemory-only mechanics —
+specifically the negative-``ttl`` shortcut for expired records, which
+RedisStore's Lua ``acquire`` rejects (``ttl_ms <= 0``) by design.
 """
 
 from __future__ import annotations

--- a/tests/test_stores_redis.py
+++ b/tests/test_stores_redis.py
@@ -1,10 +1,10 @@
 """Tests for the Redis store module that don't require a live Redis.
 
-The cross-store conformance suite (slice 5) covers the actual store
-behavior against a testcontainers Redis. The tests here pin module-level
-invariants — namespace defaults, the Lua/enum agreement, the
-``decode_responses`` guard, and per-method error-wrapping — so they
-catch regressions without needing container infrastructure.
+The cross-store conformance suite covers actual store behavior against
+a testcontainers Redis. The tests here pin module-level invariants —
+namespace defaults, the Lua/enum agreement, the ``decode_responses``
+guard, and per-method error-wrapping — so they catch regressions
+without needing container infrastructure.
 """
 
 from __future__ import annotations

--- a/tests/test_stores_redis_integration.py
+++ b/tests/test_stores_redis_integration.py
@@ -83,11 +83,9 @@ async def test_complete_raises_on_python_side_expired_record(
     """``RedisStore.complete`` raises ``StoreError`` when the existing
     record is expired by Python clock, even if PEXPIRE hasn't fired.
 
-    Symmetric with ``test_get_filters_python_side_expired_record``: the
-    in-flight TTL race that masks an expired slot from server-side
-    eviction is the exact scenario the defense exists to catch — without
-    it, ``complete`` would silently overwrite an "expired but still in
-    Redis" slot, exactly the bug fixed in InMemoryStore in slice 7.
+    Symmetric with ``test_get_filters_python_side_expired_record`` —
+    catches the sub-millisecond race that would otherwise let
+    ``complete`` silently overwrite an expired-but-still-in-Redis slot.
     """
     store = RedisStore(redis_client)
     key = IdempotencyKey("python-side-expired-complete")


### PR DESCRIPTION
## Summary

Comment-cleanup pass across `src/` and `tests/`. **Net: +109 / -243 lines.** No code logic changed; tests/coverage/lint identical before and after.

Driving observation: comments had grown over slices 1-8 of the Redis-store work (and earlier) into multi-paragraph essays that explained WHAT the code does, embedded issue/slice numbers that rot over time, and duplicated content that already lives in `docs/DESIGN.md` and `README.md`.

**Cut:**
- WHAT-comments duplicating well-named code
- Multi-line essay comments (kept the WHY in 1-2 lines)
- Issue/slice number references (`# issue #17 / slice 7`, `Slice 5 covers`, etc.) — they rot; the right home is PR descriptions and CHANGELOG
- Version-rot tags inside docstrings (`(v0.2.0)` → present-tense)
- `redis.py` module docstring's 30-line production-client config block — README has the worked example
- Paragraphs duplicated verbatim in `docs/DESIGN.md` (TTL/PEXPIRE clock split, cluster routing)

**Kept / restored after review:**
- `store.py` Protocol-contract docstrings — they ARE the spec for custom backend authors. Specifically restored the "process crashes don't call release; passive recovery via in-flight TTL" sentence on `release`.
- `CachedResponse` invariant docstring — load-bearing for the never-cached-as-stream contract
- Defense rationale for `_serde.py` (memory-DoS caps, `bytes(int)` blow-up, `bool`-is-`int`-subclass, NewType-as-runtime-no-op type-confusion). Strengthened with the threat-model note ("inputs from potentially-poisoned Redis bytes").
- `TODO(v=2)` decoder-registry hint in `_serde.py` — useful breadcrumb for the next schema bump
- NOSCRIPT/replica-failover note for `register_script`
- All non-obvious WHY (typed-raise vs assert, atomic HMGET RTT semantics, 2-RTT race in `complete`, etc.)

## Workflow

- Calibrated style on `redis.py` first; user validated, then applied to the rest in batch
- 3 independent review agents flagged 6 issues (broken DESIGN.md cross-ref, missing release-crash-recovery sentence, misleading HMGET-race wording, dropped constants-tail rationale, dropped TODO, threat-model context) — all addressed before commit

## Test plan

- [x] `pytest -m "not redis"` — 116 passed
- [x] Full suite with redis service container + coverage gate — 141 passed, total coverage 95.63%
- [x] mypy / ruff clean