### PR TITLE
fix(middleware): respond 413 on chunked-transfer body overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Chunked-transfer requests (no `Content-Length`) whose body exceeds
+  `max_body_bytes` now respond `413 Content Too Large` instead of
+  bubbling out as an unhandled `RequestTooLargeError` (which the ASGI
+  server reported as 500). The handler is not invoked and no
+  idempotency record is created. The `Content-Length` pre-check
+  pass-through behavior is unchanged (#19).
 - The internal request-body replay no longer raises `RuntimeError` on
   the second `receive()` call. Subsequent calls now forward to the
   original ASGI `receive`, so apps that listen for `http.disconnect`

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ the `Idempotency-Key` header. Outcomes:
 | Same key + different body | `422 Unprocessable Entity` |
 | Handler returned 5xx | Slot released; a retry will run the handler again. |
 | Handler returned a streaming response (`StreamingResponse`, SSE, file download) | Forwarded live; not cached. Slot released, retries run the handler again. |
+| Chunked-transfer body exceeds `max_body_bytes` | `413 Content Too Large`; handler not invoked, no slot created. |
 | Storage failed after a successful response, or any other path that won't replay on retry | `Idempotency-Stored: false` header on the response |
 
 The `Idempotency-Stored: false` header is a union signal: it appears
@@ -136,7 +137,10 @@ means the same thing for the caller: "this response will not replay
 on retry — the slot is gone."
 
 Safe methods (GET/HEAD/OPTIONS), requests without an `Idempotency-Key`,
-and requests over `max_body_bytes` pass through untouched.
+and requests whose `Content-Length` declares more than `max_body_bytes`
+pass through untouched (idempotency simply skipped). Chunked-transfer
+uploads (no `Content-Length`) over the limit get `413` instead — the
+in-buffer fence is the only defense when the header is absent.
 
 ## Roadmap
 

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -6,7 +6,7 @@ import logging
 from typing import TYPE_CHECKING, ClassVar
 
 from .body_buffer import buffer_request_body
-from .errors import StoreError
+from .errors import RequestTooLargeError, StoreError
 from .fingerprint import compute_fingerprint
 from .types import (
     AcquireOutcome,
@@ -94,10 +94,23 @@ class IdempotencyMiddleware:
         send: Send,
         key: IdempotencyKey,
     ) -> None:
-        body, replay = await buffer_request_body(
-            receive,
-            max_bytes=self.max_body_bytes,
-        )
+        try:
+            body, replay = await buffer_request_body(
+                receive,
+                max_bytes=self.max_body_bytes,
+            )
+        except RequestTooLargeError:
+            # Fixed message: never echo exception text or limit value to
+            # the client (defends against future leak via exception state).
+            # The remaining unread http.request messages are the ASGI
+            # server's responsibility — draining here would defeat
+            # early rejection of attack-sized bodies.
+            await self._send_plain_response(
+                send,
+                status=413,
+                message="request body exceeds maximum allowed size",
+            )
+            return
         fingerprint = compute_fingerprint(
             scope["method"],
             scope["path"],

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -24,6 +24,8 @@ from fastapi_idempotency import (
 from fastapi_idempotency.types import AcquireResult, IdempotencyRecord
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from starlette.types import Message, Receive, Scope, Send
 
 
@@ -350,6 +352,113 @@ async def test_oversized_body_passes_through_without_idempotency() -> None:
     assert response.content == b"a" * 200
     # Nothing was recorded — idempotency was skipped.
     assert await store.get(IdempotencyKey("x")) is None
+
+
+async def test_chunked_body_overflow_returns_413() -> None:
+    """Chunked-transfer body (no Content-Length) > max_body_bytes:
+    middleware catches ``RequestTooLargeError`` from ``buffer_request_body``
+    and responds 413 with a fixed message — no handler invocation, no
+    idempotency record."""
+    invocations = 0
+
+    async def counting_app(scope: Scope, receive: Receive, send: Send) -> None:
+        nonlocal invocations
+        invocations += 1
+        # Drain anyway so the test is honest about whether we got here.
+        while True:
+            message = await receive()
+            if message["type"] != "http.request":
+                break
+            if not message.get("more_body", False):
+                break
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            },
+        )
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    store = InMemoryStore()
+    middleware = IdempotencyMiddleware(counting_app, store, max_body_bytes=100)
+
+    async def chunks() -> AsyncIterator[bytes]:
+        # Two 60-byte chunks → 120 bytes total > max_body_bytes=100.
+        # httpx omits Content-Length when content is an async iterator,
+        # so the Content-Length pre-check can't pass-through; the
+        # in-buffer fence is the only defense.
+        yield b"a" * 60
+        yield b"b" * 60
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/",
+            headers={"Idempotency-Key": "x"},
+            content=chunks(),
+        )
+
+    assert response.status_code == 413
+    assert response.text == "request body exceeds maximum allowed size"
+    assert invocations == 0
+    assert await store.get(IdempotencyKey("x")) is None
+
+
+async def test_single_oversized_chunk_returns_413() -> None:
+    """One chunk over the limit (no Content-Length): proves the in-buffer
+    fence checks per chunk, not just on the second."""
+    invocations = 0
+
+    async def counting_app(scope: Scope, receive: Receive, send: Send) -> None:
+        nonlocal invocations
+        invocations += 1
+        await echo_app(scope, receive, send)
+
+    store = InMemoryStore()
+    middleware = IdempotencyMiddleware(counting_app, store, max_body_bytes=100)
+
+    async def chunks() -> AsyncIterator[bytes]:
+        yield b"a" * 200
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/",
+            headers={"Idempotency-Key": "x"},
+            content=chunks(),
+        )
+
+    assert response.status_code == 413
+    assert response.text == "request body exceeds maximum allowed size"
+    assert invocations == 0
+
+
+async def test_chunked_body_at_exact_limit_passes() -> None:
+    """Boundary: ``total > max_bytes`` (strict greater-than) — a body of
+    exactly ``max_body_bytes`` must succeed."""
+    store = InMemoryStore()
+    middleware = IdempotencyMiddleware(echo_app, store, max_body_bytes=100)
+
+    async def chunks() -> AsyncIterator[bytes]:
+        yield b"a" * 100
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/",
+            headers={"Idempotency-Key": "x"},
+            content=chunks(),
+        )
+
+    assert response.status_code == 200
+    assert response.content == b"a" * 100
 
 
 async def test_undersized_body_uses_idempotency() -> None:


### PR DESCRIPTION
Closes #19

## Summary

Chunked-transfer requests (no `Content-Length`) whose body exceeds `max_body_bytes` were bubbling out as `RequestTooLargeError` from `buffer_request_body` — uncaught, the ASGI server reported `500`. The buffer-overrun is a client mistake, not a server bug; `500` misled.

The middleware now catches `RequestTooLargeError` after `buffer_request_body` and responds `413 Content Too Large` with a fixed plain-text body. The handler is not invoked and no idempotency record is created. The existing `Content-Length` pre-check pass-through (oversized declared length → idempotency skipped, request flows to handler untouched) is unchanged.

### Design decisions

- **Fixed response body** (`request body exceeds maximum allowed size`) — built in middleware, not echoed from `str(exc)` and not including the configured `max_body_bytes` value. Defense-in-depth against future leak via exception-state changes; security stance favors zero info disclosure of server config.
- **Narrow catch scope** — only wraps `buffer_request_body`. Future bounds-checks added to `acquire`/`complete` will not be silently surfaced as `413`.
- **Unread `http.request` messages left to the ASGI server** — draining in the middleware would defeat the purpose of early-rejecting attack-sized bodies.
- **No `Idempotency-Stored: false` header** — the slot was never created (`acquire` is not called on this path), so the "won't replay" union signal does not apply.

## Test plan

- [x] `pytest -m "not redis"` — 119 passed locally
- [x] Full suite with redis service container + coverage gate — 144 passed locally, total coverage 95.98%
- [x] Three new tests: `test_chunked_body_overflow_returns_413`, `test_single_oversized_chunk_returns_413`, `test_chunked_body_at_exact_limit_passes`
- [x] Existing `test_oversized_body_passes_through_without_idempotency` (Content-Length pre-check) keeps passing — no regression on the buffered-pass-through path