### PR TITLE
feat(security): mandatory HMAC fingerprint with explicit secret=None opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** (pre-1.0): `IdempotencyMiddleware(...)` now requires a
+  `secret=` keyword argument. Pass `secret=os.environ['IDEMP_SECRET']
+  .encode()` to enable HMAC-SHA256 request fingerprints (recommended
+  for any shared-store deployment), or `secret=None` to explicitly opt
+  into the v0.1.0 plain-SHA-256 fallback. Omitting the kwarg raises
+  `ValueError` at construction — no silent insecure default. Two
+  deployments sharing a store must use the same secret; different
+  secrets produce different fingerprints (#20).
+
 ### Added
 
 - Streaming response pass-through (#18). FastAPI / Starlette

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ pip install \
 ### FastAPI
 
 ```python
+import os
+
 from fastapi import FastAPI
 from pydantic import BaseModel
 
@@ -37,7 +39,11 @@ class Order(BaseModel):
 
 
 app = FastAPI()
-app.add_middleware(IdempotencyMiddleware, store=InMemoryStore())
+app.add_middleware(
+    IdempotencyMiddleware,
+    store=InMemoryStore(),
+    secret=os.environ["IDEMP_SECRET"].encode(),
+)
 
 
 @app.post("/orders")
@@ -45,6 +51,35 @@ async def create_order(order: Order) -> dict[str, int]:
     # Your business logic — runs at most once per Idempotency-Key.
     return {"id": 42, "item_id": order.item_id}
 ```
+
+`secret=` is required — it switches the request fingerprint from plain
+SHA-256 to HMAC-SHA256, so an attacker who knows someone's
+`Idempotency-Key` can't probe via `MISMATCH`/`REPLAY` outcomes to learn
+body shape. Two deployments sharing a store must use the **same**
+secret; different secrets produce different fingerprints.
+
+Generate the secret once and inject it via environment:
+
+```bash
+export IDEMP_SECRET="$(openssl rand -hex 32)"
+```
+
+The middleware fails at construction (`KeyError` from `os.environ[...]`)
+if the variable isn't set — fail-fast at deploy is preferred over a
+runtime surprise.
+
+#### Insecure opt-out (tests / migration only)
+
+`secret=None` explicitly disables HMAC and falls back to v0.1.0's plain
+SHA-256. Acceptable in tests; **not** safe for any shared-store
+deployment.
+
+#### Secret rotation
+
+Rotating the secret invalidates every cached and in-flight record (they
+hash with the old secret, look like `MISMATCH` to requests under the
+new one). To rotate safely, drain `completed_ttl` first, or accept that
+in-flight retries during the rotation window behave as new requests.
 
 Send the same request twice with `Idempotency-Key: abc-123`:
 
@@ -55,6 +90,8 @@ Send the same request twice with `Idempotency-Key: abc-123`:
 ### Starlette
 
 ```python
+import os
+
 from starlette.applications import Starlette
 from starlette.responses import JSONResponse
 from starlette.routing import Route
@@ -68,7 +105,11 @@ async def create_order(request):
 
 
 app = Starlette(routes=[Route("/orders", create_order, methods=["POST"])])
-app = IdempotencyMiddleware(app, InMemoryStore())
+app = IdempotencyMiddleware(
+    app,
+    InMemoryStore(),
+    secret=os.environ["IDEMP_SECRET"].encode(),
+)
 ```
 
 ### Redis (multi-worker / multi-process)
@@ -87,9 +128,11 @@ pip install \
 ```
 
 ```python
-import redis.asyncio
+import os
 
+import redis.asyncio
 from fastapi import FastAPI
+
 from fastapi_idempotency import IdempotencyMiddleware, RedisStore
 
 # Production-recommended client config — see RedisStore docstring for
@@ -104,7 +147,11 @@ client = redis.asyncio.Redis(
 )
 
 app = FastAPI()
-app.add_middleware(IdempotencyMiddleware, store=RedisStore(client))
+app.add_middleware(
+    IdempotencyMiddleware,
+    store=RedisStore(client),
+    secret=os.environ["IDEMP_SECRET"].encode(),
+)
 ```
 
 Atomicity: `acquire` is a single Lua `EVAL`, so concurrent workers

--- a/src/fastapi_idempotency/fingerprint.py
+++ b/src/fastapi_idempotency/fingerprint.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 
 from .types import Fingerprint
 
@@ -12,18 +13,29 @@ def compute_fingerprint(
     path: str,
     query_string: bytes,
     body: bytes,
+    *,
+    secret: bytes | None = None,
 ) -> Fingerprint:
     """Compute a stable fingerprint over ``method + path + query + body``.
 
-    Returns a hex-encoded SHA-256 digest. Each component is length-prefixed
+    Returns a hex-encoded digest. Each component is length-prefixed
     before being fed to the hasher so prefix-aligned ambiguity is
-    impossible (e.g., ``method="POS", path="T/foo"`` cannot collide with
-    ``method="POST", path="/foo"``).
+    impossible (e.g., ``method="POS", path="T/foo"`` cannot collide
+    with ``method="POST", path="/foo"``).
 
-    Argument types follow the ASGI scope shape: ``path`` is ``str``,
-    ``query_string`` is raw ``bytes``.
+    When ``secret`` is provided, switches to HMAC-SHA256 — without the
+    secret an attacker can't construct fingerprints for arbitrary
+    bodies, so they can't probe via ``MISMATCH``/``REPLAY`` outcomes.
+    Plain SHA-256 (``secret=None``) is kept for v0.1.0 backward
+    compatibility but is explicitly insecure for shared-store deployments.
+
+    Empty bytes (``secret=b""``) is rejected — it's a cryptographically
+    trivial HMAC key. The explicit "no HMAC" opt-out is ``secret=None``.
     """
-    h = hashlib.sha256()
+    if secret is not None and len(secret) == 0:
+        msg = "HMAC secret must be non-empty; use secret=None to opt out explicitly"
+        raise ValueError(msg)
+    h = hmac.new(secret, digestmod=hashlib.sha256) if secret is not None else hashlib.sha256()
     for part in (
         method.encode("ascii"),
         path.encode("utf-8"),

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -23,6 +23,22 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class _Missing:
+    """Sentinel type for the ``secret`` kwarg default.
+
+    Forces callers to choose ``secret=os.environ[...].encode()`` (HMAC)
+    or ``secret=None`` (explicit insecure mode) at construction. Typed
+    as its own class so ``mypy --strict`` narrows correctly inside the
+    ``isinstance`` guard rather than falling back to ``Any``.
+    """
+
+    def __repr__(self) -> str:
+        return "<unset>"
+
+
+_SECRET_NOT_SET = _Missing()
+
+
 class IdempotencyMiddleware:
     """ASGI middleware enforcing ``Idempotency-Key`` semantics.
 
@@ -42,13 +58,22 @@ class IdempotencyMiddleware:
         app: ASGIApp,
         store: Store,
         *,
+        secret: bytes | None | _Missing = _SECRET_NOT_SET,
         header_name: str = "Idempotency-Key",
         in_flight_ttl: float = 30.0,
         completed_ttl: float = 86_400.0,
         max_body_bytes: int | None = None,
     ) -> None:
+        if isinstance(secret, _Missing):
+            msg = (
+                "secret= is required. Pass "
+                "`secret=os.environ['IDEMP_SECRET'].encode()` for HMAC-SHA256 "
+                "fingerprints. See README for the opt-out path used in tests."
+            )
+            raise ValueError(msg)
         self.app = app
         self.store = store
+        self._secret: bytes | None = secret
         self.header_name = header_name
         self.in_flight_ttl = in_flight_ttl
         self.completed_ttl = completed_ttl
@@ -116,6 +141,7 @@ class IdempotencyMiddleware:
             scope["path"],
             scope.get("query_string", b""),
             body,
+            secret=self._secret,
         )
 
         result = await self.store.acquire(

--- a/src/fastapi_idempotency/stores/memory.py
+++ b/src/fastapi_idempotency/stores/memory.py
@@ -56,6 +56,8 @@ class InMemoryStore:
                 self._records[key] = record
                 return AcquireResult(outcome=AcquireOutcome.CREATED, record=record)
 
+            # Plain ``!=`` is fine: both fingerprints are server-computed
+            # over attacker-supplied body, so timing leaks no useful bits.
             if existing.fingerprint != fingerprint:
                 return AcquireResult(outcome=AcquireOutcome.MISMATCH, record=existing)
 

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from fastapi_idempotency.fingerprint import compute_fingerprint
 
 
@@ -57,5 +59,97 @@ def test_prefix_aligned_inputs_do_not_collide() -> None:
 
 def test_empty_body_works() -> None:
     fp = compute_fingerprint("POST", "/orders", b"", b"")
+
+    assert len(fp) == 64
+
+
+# ---------------------------------------------------------------------------
+# HMAC mode (secret=bytes)
+# ---------------------------------------------------------------------------
+
+
+def test_hmac_returns_64_char_hex_sha256() -> None:
+    fp = compute_fingerprint("POST", "/orders", b"", b"", secret=b"k")
+
+    assert len(fp) == 64
+    assert all(c in "0123456789abcdef" for c in fp)
+
+
+def test_hmac_deterministic_for_same_secret_and_inputs() -> None:
+    fp1 = compute_fingerprint("POST", "/orders", b"x=1", b'{"id":1}', secret=b"k")
+    fp2 = compute_fingerprint("POST", "/orders", b"x=1", b'{"id":1}', secret=b"k")
+
+    assert fp1 == fp2
+
+
+def test_hmac_different_secret_changes_fingerprint() -> None:
+    """The point of HMAC: same inputs, different secret → different fingerprint
+    (so an attacker without the secret can't reproduce fingerprints)."""
+    a = compute_fingerprint("POST", "/orders", b"", b"", secret=b"secret-1")
+    b = compute_fingerprint("POST", "/orders", b"", b"", secret=b"secret-2")
+
+    assert a != b
+
+
+def test_hmac_differs_from_plain_sha256() -> None:
+    """HMAC vs plain: same inputs but secret=None vs secret=b'...' must
+    produce different fingerprints — stores cannot be shared across modes."""
+    plain = compute_fingerprint("POST", "/orders", b"", b"", secret=None)
+    hmac_fp = compute_fingerprint("POST", "/orders", b"", b"", secret=b"k")
+
+    assert plain != hmac_fp
+
+
+def test_hmac_body_change_still_changes_fingerprint() -> None:
+    """Length-prefix scheme + HMAC: a body flip flips the fingerprint."""
+    a = compute_fingerprint("POST", "/orders", b"", b'{"id":1}', secret=b"k")
+    b = compute_fingerprint("POST", "/orders", b"", b'{"id":2}', secret=b"k")
+
+    assert a != b
+
+
+def test_hmac_prefix_aligned_inputs_do_not_collide() -> None:
+    """Length-prefix defense holds under HMAC too."""
+    a = compute_fingerprint("POST", "/foo", b"", b"", secret=b"k")
+    b = compute_fingerprint("POS", "T/foo", b"", b"", secret=b"k")
+
+    assert a != b
+
+
+def test_hmac_empty_secret_rejected() -> None:
+    """``secret=b""`` is a cryptographically trivial HMAC key. The
+    explicit "no HMAC" opt-out is ``secret=None``."""
+    with pytest.raises(ValueError, match="non-empty"):
+        compute_fingerprint("POST", "/orders", b"", b"", secret=b"")
+
+
+def test_hmac_long_secret_above_block_size() -> None:
+    """HMAC pre-hashes keys longer than the block size (64 bytes for
+    SHA-256). Verify the long-key path still produces a stable digest
+    and stays deterministic."""
+    long_secret = b"k" * 200  # 3x block size
+    a = compute_fingerprint("POST", "/orders", b"", b"body", secret=long_secret)
+    b = compute_fingerprint("POST", "/orders", b"", b"body", secret=long_secret)
+    different = compute_fingerprint(
+        "POST",
+        "/orders",
+        b"",
+        b"body",
+        secret=long_secret + b"x",
+    )
+
+    assert a == b
+    assert a != different
+
+
+def test_hmac_non_ascii_secret_bytes() -> None:
+    """Secret bytes are opaque to the codec — non-ASCII payloads work."""
+    fp = compute_fingerprint(
+        "POST",
+        "/orders",
+        b"",
+        b"body",
+        secret=b"\xf0\x9f\x94\x91",
+    )
 
     assert len(fp) == 64

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -11,6 +11,7 @@ import contextlib
 from typing import TYPE_CHECKING, Any
 
 import httpx
+import pytest
 
 from fastapi_idempotency import (
     CachedResponse,
@@ -52,11 +53,77 @@ async def echo_app(scope: Scope, receive: Receive, send: Send) -> None:
 
 
 def make_client(app: Any) -> httpx.AsyncClient:
-    middleware = IdempotencyMiddleware(app, InMemoryStore())
+    middleware = IdempotencyMiddleware(app, InMemoryStore(), secret=None)
     return httpx.AsyncClient(
         transport=httpx.ASGITransport(app=middleware),
         base_url="http://testserver",
     )
+
+
+def test_missing_secret_kwarg_raises_value_error() -> None:
+    """``IdempotencyMiddleware(app, store)`` without ``secret=`` must fail
+    loudly — the middleware never silently picks an insecure fingerprint mode."""
+    with pytest.raises(ValueError, match="secret="):
+        IdempotencyMiddleware(echo_app, InMemoryStore())
+
+
+async def test_hmac_secret_caches_response() -> None:
+    """End-to-end smoke: a non-None ``secret`` produces working idempotency
+    (HMAC fingerprint flows through acquire/complete/replay)."""
+    store = InMemoryStore()
+    middleware = IdempotencyMiddleware(echo_app, store, secret=b"production-secret")
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        first = await client.post(
+            "/",
+            headers={"Idempotency-Key": "k"},
+            content=b"hi",
+        )
+        second = await client.post(
+            "/",
+            headers={"Idempotency-Key": "k"},
+            content=b"hi",
+        )
+
+    assert first.status_code == 200
+    assert second.headers["idempotent-replayed"] == "true"
+
+
+async def test_hmac_different_secret_isolates_fingerprint() -> None:
+    """Two middlewares with different secrets but the same store and key:
+    fingerprints don't collide, so reuse-with-altered-body detection (422)
+    works as if the bodies were different."""
+    store = InMemoryStore()
+
+    m1 = IdempotencyMiddleware(echo_app, store, secret=b"secret-A")
+    m2 = IdempotencyMiddleware(echo_app, store, secret=b"secret-B")
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=m1),
+        base_url="http://testserver",
+    ) as c1:
+        first = await c1.post(
+            "/",
+            headers={"Idempotency-Key": "k"},
+            content=b"body",
+        )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=m2),
+        base_url="http://testserver",
+    ) as c2:
+        second = await c2.post(
+            "/",
+            headers={"Idempotency-Key": "k"},
+            content=b"body",
+        )
+
+    # Same key + same body bytes, but different secrets → different
+    # fingerprints → middleware #2 sees MISMATCH, not REPLAY.
+    assert first.status_code == 200
+    assert second.status_code == 422
 
 
 async def test_get_passes_through_to_handler() -> None:
@@ -89,7 +156,7 @@ async def test_non_http_scope_passes_through() -> None:
     async def app(scope: Scope, _receive: Receive, _send: Send) -> None:
         seen_scopes.append(scope["type"])
 
-    middleware = IdempotencyMiddleware(app, InMemoryStore())
+    middleware = IdempotencyMiddleware(app, InMemoryStore(), secret=None)
 
     async def _noop_receive() -> Message:
         return {"type": "lifespan.startup"}
@@ -151,7 +218,7 @@ async def test_first_post_runs_handler_and_returns_response() -> None:
 
 async def test_first_post_stores_completed_record() -> None:
     store = InMemoryStore()
-    middleware = IdempotencyMiddleware(echo_app, store)
+    middleware = IdempotencyMiddleware(echo_app, store, secret=None)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=middleware),
@@ -231,7 +298,7 @@ async def test_5xx_response_releases_slot() -> None:
         await send({"type": "http.response.body", "body": b"oops"})
 
     store = InMemoryStore()
-    middleware = IdempotencyMiddleware(server_error_app, store)
+    middleware = IdempotencyMiddleware(server_error_app, store, secret=None)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=middleware),
@@ -276,7 +343,7 @@ async def test_5xx_then_retry_runs_handler_again() -> None:
             {"type": "http.response.body", "body": str(invocations).encode()},
         )
 
-    middleware = IdempotencyMiddleware(flaky_app, InMemoryStore())
+    middleware = IdempotencyMiddleware(flaky_app, InMemoryStore(), secret=None)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=middleware),
@@ -317,7 +384,7 @@ async def test_handler_exception_releases_slot() -> None:
         raise RuntimeError(msg)
 
     store = InMemoryStore()
-    middleware = IdempotencyMiddleware(boom_app, store)
+    middleware = IdempotencyMiddleware(boom_app, store, secret=None)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=middleware),
@@ -336,7 +403,7 @@ async def test_handler_exception_releases_slot() -> None:
 async def test_oversized_body_passes_through_without_idempotency() -> None:
     """Content-Length over max_body_bytes → handler runs, no slot recorded."""
     store = InMemoryStore()
-    middleware = IdempotencyMiddleware(echo_app, store, max_body_bytes=100)
+    middleware = IdempotencyMiddleware(echo_app, store, max_body_bytes=100, secret=None)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=middleware),
@@ -381,7 +448,7 @@ async def test_chunked_body_overflow_returns_413() -> None:
         await send({"type": "http.response.body", "body": b"ok"})
 
     store = InMemoryStore()
-    middleware = IdempotencyMiddleware(counting_app, store, max_body_bytes=100)
+    middleware = IdempotencyMiddleware(counting_app, store, max_body_bytes=100, secret=None)
 
     async def chunks() -> AsyncIterator[bytes]:
         # Two 60-byte chunks → 120 bytes total > max_body_bytes=100.
@@ -418,7 +485,7 @@ async def test_single_oversized_chunk_returns_413() -> None:
         await echo_app(scope, receive, send)
 
     store = InMemoryStore()
-    middleware = IdempotencyMiddleware(counting_app, store, max_body_bytes=100)
+    middleware = IdempotencyMiddleware(counting_app, store, max_body_bytes=100, secret=None)
 
     async def chunks() -> AsyncIterator[bytes]:
         yield b"a" * 200
@@ -442,7 +509,7 @@ async def test_chunked_body_at_exact_limit_passes() -> None:
     """Boundary: ``total > max_bytes`` (strict greater-than) — a body of
     exactly ``max_body_bytes`` must succeed."""
     store = InMemoryStore()
-    middleware = IdempotencyMiddleware(echo_app, store, max_body_bytes=100)
+    middleware = IdempotencyMiddleware(echo_app, store, max_body_bytes=100, secret=None)
 
     async def chunks() -> AsyncIterator[bytes]:
         yield b"a" * 100
@@ -464,7 +531,7 @@ async def test_chunked_body_at_exact_limit_passes() -> None:
 async def test_undersized_body_uses_idempotency() -> None:
     """Sanity: when Content-Length is within the limit, the slot is recorded."""
     store = InMemoryStore()
-    middleware = IdempotencyMiddleware(echo_app, store, max_body_bytes=100)
+    middleware = IdempotencyMiddleware(echo_app, store, max_body_bytes=100, secret=None)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=middleware),
@@ -516,7 +583,7 @@ async def test_store_error_on_complete_adds_idempotency_stored_false_header() ->
         async def release(self, key: IdempotencyKey) -> None:
             await self._inner.release(key)
 
-    middleware = IdempotencyMiddleware(echo_app, FailingCompleteStore())
+    middleware = IdempotencyMiddleware(echo_app, FailingCompleteStore(), secret=None)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=middleware),
@@ -568,6 +635,7 @@ async def test_in_flight_ttl_expiry_reclaims_orphaned_slot() -> None:
         slow_handler,
         InMemoryStore(),
         in_flight_ttl=0.02,
+        secret=None,
     )
 
     async with httpx.AsyncClient(

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -191,7 +191,7 @@ def _make_streaming_app(chunks: list[bytes]) -> Any:
 
 async def test_streaming_response_flows_through_with_stored_false_header() -> None:
     chunks = [b"first ", b"second ", b"third"]
-    middleware = IdempotencyMiddleware(_make_streaming_app(chunks), InMemoryStore())
+    middleware = IdempotencyMiddleware(_make_streaming_app(chunks), InMemoryStore(), secret=None)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=middleware),
@@ -227,7 +227,7 @@ async def test_streaming_response_releases_slot_so_retry_runs_handler_again() ->
         await send({"type": "http.response.body", "body": b"b", "more_body": False})
 
     store = InMemoryStore()
-    middleware = IdempotencyMiddleware(streaming_app, store)
+    middleware = IdempotencyMiddleware(streaming_app, store, secret=None)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=middleware),
@@ -272,7 +272,7 @@ async def test_non_streaming_response_still_caches_and_replays() -> None:
             {"type": "http.response.body", "body": b'{"ok":true}', "more_body": False},
         )
 
-    middleware = IdempotencyMiddleware(single_chunk_app, InMemoryStore())
+    middleware = IdempotencyMiddleware(single_chunk_app, InMemoryStore(), secret=None)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=middleware),
@@ -322,7 +322,7 @@ async def test_streaming_app_raises_mid_stream_releases_slot() -> None:
         await send({"type": "http.response.body", "body": b"b", "more_body": False})
 
     store = InMemoryStore()
-    middleware = IdempotencyMiddleware(flaky_streaming_app, store)
+    middleware = IdempotencyMiddleware(flaky_streaming_app, store, secret=None)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=middleware),
@@ -359,7 +359,7 @@ async def test_handler_returns_without_emitting_start_yields_500() -> None:
         await _drive_request_lifecycle(receive)
 
     store = InMemoryStore()
-    middleware = IdempotencyMiddleware(silent_app, store)
+    middleware = IdempotencyMiddleware(silent_app, store, secret=None)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=middleware),
@@ -385,6 +385,7 @@ async def test_streaming_with_empty_body_first_chunk_still_detected() -> None:
     middleware = IdempotencyMiddleware(
         _make_streaming_app([b"", b"data"]),
         InMemoryStore(),
+        secret=None,
     )
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=middleware),
@@ -421,7 +422,7 @@ async def test_starlette_streaming_response_passes_through() -> None:
     app = Starlette(
         routes=[Route("/stream", stream_endpoint, methods=["POST"])],
     )
-    middleware = IdempotencyMiddleware(app, InMemoryStore())
+    middleware = IdempotencyMiddleware(app, InMemoryStore(), secret=None)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=middleware),


### PR DESCRIPTION
Closes #20

## Summary

Plain SHA-256 request fingerprints are deterministic: an attacker who knows someone's `Idempotency-Key` can compute the fingerprint of arbitrary bodies and probe via `MISMATCH` / `REPLAY` outcomes to learn body shape. HMAC with a server-side secret defeats this — without the secret, the attacker can't construct fingerprints.

**Breaking change** (pre-1.0): `IdempotencyMiddleware(...)` now requires a `secret=` keyword argument. Omitting it raises `ValueError` at construction — no silent insecure default.

- **`compute_fingerprint`** gains an optional `secret: bytes | None = None`. When provided, switches to HMAC-SHA256 over the existing length-prefixed payload. `secret=None` keeps plain SHA-256 (the v0.1.0 fallback). `secret=b""` is rejected as a cryptographically trivial HMAC key.
- **`IdempotencyMiddleware.__init__`** adds `secret` keyword-only with a `_Missing` sentinel default — `isinstance(secret, _Missing)` raises `ValueError("secret= is required. ...")`. `_Missing` is a typed class (not bare `object()`) so `mypy --strict` narrows correctly inside the guard and `self._secret: bytes | None` is type-clean.
- **Mechanical test updates**: 20 existing `IdempotencyMiddleware(...)` instantiations across the test suite now pass `secret=None` explicitly. Existing behavioral tests untouched semantically.
- **New tests**: HMAC determinism, sensitivity, plain-vs-HMAC distinctness, prefix-aligned defense under HMAC, empty-secret rejection, long-secret (>block size) path, non-ASCII secret bytes, `ValueError` on missing kwarg, end-to-end caching, two-secrets-isolate-fingerprint.
- **Docs**: README adds the `secret=` parameter to FastAPI / Starlette / Redis quickstarts; a separate "Insecure opt-out" subsection for `secret=None`; secret-rotation operational note; `openssl rand -hex 32` helper. CHANGELOG entry under `### Changed` flagged as breaking (pre-1.0).

## Design decisions

- **Secret rotation** — invalidates every cached and in-flight record (they hash with the old secret, look like `MISMATCH` to requests under the new one). Documented operational guidance in README: drain `completed_ttl` first, or accept that in-flight retries during the rotation window behave as new requests.
- **Empty secret rejected** — `b""` is cryptographically trivial as an HMAC key; the only documented "no HMAC" path is `secret=None`.
- **`bytes`, not `str`** — unambiguous encoding boundary, matches `hmac.new`'s API; callers do `os.environ["X"].encode()`.
- **Plain `!=` for fingerprint compare** — both operands are server-computed; the attacker never submits a fingerprint, so timing-safe compare would be cargo-cult.

## Test plan

- [x] `pytest -m "not redis"` — 131 passed locally
- [x] Full suite with redis service container + coverage gate — 156 passed locally, total coverage 96.07%
- [x] mypy / ruff clean (sentinel typing verified under `--strict`)