### PR TITLE
fix(security): strip volatile response headers before caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Strip volatile response headers (`Set-Cookie`, `Authorization`,
+  `WWW-Authenticate`, `Proxy-Authenticate`, `Cookie`) and
+  connection-level headers (`Connection`, `Keep-Alive`,
+  `Transfer-Encoding`, `Upgrade`, `Trailer`) before caching a
+  response. Previously the cache stored every header from the first
+  response verbatim and re-emitted them on replay — a session-theft
+  primitive in shared-store deployments where two requests share an
+  `Idempotency-Key`. The first caller still receives the handler's
+  original headers untouched; only the stored copy is filtered. Carried
+  over from v0.1.0; documented in `docs/DESIGN.md` ("Volatile response
+  headers stripped before caching"). (#21)
+
 ### Changed
 
 - **BREAKING** (pre-1.0): `IdempotencyMiddleware(...)` now requires a

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ the `Idempotency-Key` header. Outcomes:
 | --- | --- |
 | First request with a given key | Handler runs; response is returned and cached. |
 | Same key + same body, while the first is still in flight | `409 Conflict` |
-| Same key + same body, after the first completed | Cached response with `Idempotent-Replayed: true` header |
+| Same key + same body, after the first completed | Cached response with `Idempotent-Replayed: true` header; volatile headers (`Set-Cookie`, `Authorization`, etc.) stripped — see DESIGN.md |
 | Same key + different body | `422 Unprocessable Entity` |
 | Handler returned 5xx | Slot released; a retry will run the handler again. |
 | Handler returned a streaming response (`StreamingResponse`, SSE, file download) | Forwarded live; not cached. Slot released, retries run the handler again. |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -208,6 +208,34 @@ them via `_send_response` without per-record streaming logic. Future
 contributors adding a `complete_streaming` path would have to
 preserve this invariant or rework the REPLAY emit.
 
+## Volatile response headers stripped before caching
+
+**Status: v0.2.0.**
+
+Caching response headers verbatim is a security bug: `Set-Cookie`
+carries session tokens, `Authorization` echoes leak credentials, and
+`WWW-Authenticate` challenges encode realm/nonce state tied to the
+first caller. Re-emitting any of these on replay hands them to
+whoever presents the same `Idempotency-Key` — a session-theft
+primitive in shared-store or multi-tenant deployments.
+
+`_run_and_cache` therefore filters a hard-coded denylist before
+constructing `CachedResponse`. The **first** caller still receives
+the handler's original headers untouched; only the stored copy (and
+the REPLAY emission derived from it) is filtered.
+
+Denylist (`_VOLATILE_HEADER_DENYLIST` in `middleware.py`):
+
+- Identity-bearing: `set-cookie`, `authorization`,
+  `proxy-authorization`, `www-authenticate`, `proxy-authenticate`,
+  `cookie`
+- Connection-level (RFC 9110 §7.6.1 forbids caching): `connection`,
+  `keep-alive`, `transfer-encoding`, `upgrade`, `trailer`
+
+Hard-coded for v0.2.0. v0.3.0 may expose a constructor kwarg
+(`volatile_headers=[...]`) so deployments with custom headers
+(e.g. proprietary auth-context echoes) can extend the list.
+
 ## Why msgpack over JSON
 
 _To be written during v0.1.0._

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -39,6 +39,35 @@ class _Missing:
 _SECRET_NOT_SET = _Missing()
 
 
+# Headers dropped from the cached response — prevents session/credential
+# leak on REPLAY. See ``docs/DESIGN.md`` ("Volatile response headers")
+# for the threat model and denylist split.
+_VOLATILE_HEADER_DENYLIST: frozenset[bytes] = frozenset(
+    {
+        b"set-cookie",
+        b"authorization",
+        b"proxy-authorization",
+        b"www-authenticate",
+        b"proxy-authenticate",
+        b"cookie",
+        b"connection",
+        b"keep-alive",
+        b"transfer-encoding",
+        b"upgrade",
+        b"trailer",
+    },
+)
+
+
+def _strip_volatile_headers(
+    headers: tuple[tuple[bytes, bytes], ...],
+) -> tuple[tuple[bytes, bytes], ...]:
+    """Drop denylisted headers (case-insensitive) for caching."""
+    return tuple(
+        (name, value) for name, value in headers if name.lower() not in _VOLATILE_HEADER_DENYLIST
+    )
+
+
 class IdempotencyMiddleware:
     """ASGI middleware enforcing ``Idempotency-Key`` semantics.
 
@@ -238,9 +267,11 @@ class IdempotencyMiddleware:
             )
             return
 
+        # Strip for the cached copy only; the first caller below
+        # receives ``interceptor.headers`` untouched.
         cached = CachedResponse(
             status_code=interceptor.status,
-            headers=interceptor.headers,
+            headers=_strip_volatile_headers(interceptor.headers),
             body=bytes(interceptor.body),
         )
         extra_headers: list[tuple[bytes, bytes]] = []

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -22,6 +22,10 @@ from fastapi_idempotency import (
     InMemoryStore,
     StoreError,
 )
+from fastapi_idempotency.middleware import (
+    _VOLATILE_HEADER_DENYLIST,
+    _strip_volatile_headers,
+)
 from fastapi_idempotency.types import AcquireResult, IdempotencyRecord
 
 if TYPE_CHECKING:
@@ -255,6 +259,139 @@ async def test_replay_returns_cached_response_with_replayed_header() -> None:
     assert second.status_code == 200
     assert second.content == b"hello"
     assert second.headers["idempotent-replayed"] == "true"
+
+
+async def test_replay_strips_volatile_headers_but_keeps_safe_ones() -> None:
+    """Set-Cookie, Authorization etc. on the first response must NOT be
+    re-emitted on replay — otherwise whoever presents the same key gets
+    the first caller's session. Safe headers (Content-Type, custom X-*)
+    stay. The first caller still sees the originals."""
+
+    async def app_with_volatile_headers(
+        _scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        while True:
+            message = await receive()
+            if message["type"] != "http.request":
+                break
+            if not message.get("more_body", False):
+                break
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"set-cookie", b"session=A; HttpOnly"),
+                    (b"authorization", b"Bearer leaked"),
+                    (b"www-authenticate", b"Basic realm=x"),
+                    (b"x-trace-id", b"req-1"),
+                ],
+            },
+        )
+        await send({"type": "http.response.body", "body": b'{"ok":true}'})
+
+    async with make_client(app_with_volatile_headers) as client:
+        first = await client.post(
+            "/",
+            headers={"Idempotency-Key": "abc"},
+            content=b"hi",
+        )
+        replay = await client.post(
+            "/",
+            headers={"Idempotency-Key": "abc"},
+            content=b"hi",
+        )
+
+    # First response carries everything — handler's caller sees its own
+    # cookie etc.
+    assert first.headers.get("set-cookie") == "session=A; HttpOnly"
+    assert first.headers.get("authorization") == "Bearer leaked"
+
+    # Replay drops identity-bearing headers.
+    assert replay.headers.get("idempotent-replayed") == "true"
+    assert "set-cookie" not in replay.headers
+    assert "authorization" not in replay.headers
+    assert "www-authenticate" not in replay.headers
+    # Safe headers preserved.
+    assert replay.headers.get("content-type") == "application/json"
+    assert replay.headers.get("x-trace-id") == "req-1"
+
+
+async def test_volatile_header_denylist_is_case_insensitive() -> None:
+    """ASGI lowercases header names per spec, but handlers may set them
+    in any case via a non-conforming app. Verify ``Set-Cookie`` (mixed
+    case) is still stripped."""
+    stripped = _strip_volatile_headers(
+        (
+            (b"Set-Cookie", b"a=1"),
+            (b"SET-COOKIE", b"b=2"),
+            (b"Content-Type", b"text/plain"),
+        ),
+    )
+
+    assert (b"Content-Type", b"text/plain") in stripped
+    assert all(name.lower() != b"set-cookie" for name, _ in stripped)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        b"set-cookie",
+        b"authorization",
+        b"proxy-authorization",
+        b"www-authenticate",
+        b"proxy-authenticate",
+        b"cookie",
+        b"connection",
+        b"keep-alive",
+        b"transfer-encoding",
+        b"upgrade",
+        b"trailer",
+    ],
+)
+def test_each_denylisted_header_is_stripped(name: bytes) -> None:
+    """Pin every entry in the denylist — a typo in any single header
+    name (e.g., ``www-authenitcate``) slips past integration coverage."""
+    stripped = _strip_volatile_headers(((name, b"value"),))
+
+    assert stripped == ()
+
+
+def test_denylist_entries_are_all_lowercase() -> None:
+    """Lookup compares against ``name.lower()``; a capitalized entry in
+    the frozenset (e.g., ``b"Set-Cookie"``) would silently never match
+    and become dead code."""
+    for entry in _VOLATILE_HEADER_DENYLIST:
+        assert entry == entry.lower()
+
+
+def test_strip_volatile_headers_preserves_safe_headers() -> None:
+    """Connection-level entries drop; common safe headers
+    (Content-Type, Content-Length, custom X-*, security headers)
+    survive — guards against an overzealous denylist regression."""
+    stripped = _strip_volatile_headers(
+        (
+            (b"connection", b"keep-alive"),
+            (b"keep-alive", b"timeout=5"),
+            (b"transfer-encoding", b"chunked"),
+            (b"upgrade", b"h2c"),
+            (b"trailer", b"x-tail"),
+            (b"content-type", b"application/json"),
+            (b"content-length", b"42"),
+            (b"strict-transport-security", b"max-age=31536000"),
+            (b"x-trace-id", b"abc"),
+        ),
+    )
+
+    assert stripped == (
+        (b"content-type", b"application/json"),
+        (b"content-length", b"42"),
+        (b"strict-transport-security", b"max-age=31536000"),
+        (b"x-trace-id", b"abc"),
+    )
 
 
 async def test_same_key_different_body_returns_422() -> None:


### PR DESCRIPTION
Closes #21

## Summary

`_run_and_cache` used to store every response header from the first request verbatim and re-emit them on `REPLAY`. That includes `Set-Cookie` — a session-theft primitive in any deployment where two requests can share an `Idempotency-Key`. This PR strips a hard-coded denylist before constructing `CachedResponse`. The first caller still receives the handler's original headers untouched; only the stored copy (and any REPLAY emission derived from it) is filtered.

**Denylist** (`middleware._VOLATILE_HEADER_DENYLIST`, lowercased `frozenset[bytes]` for O(1) lookup):
- **Identity-bearing**: `set-cookie`, `authorization`, `proxy-authorization`, `www-authenticate`, `proxy-authenticate`, `cookie`
- **Connection-level** (RFC 9110 §7.6.1 forbids caching): `connection`, `keep-alive`, `transfer-encoding`, `upgrade`, `trailer`

Hard-coded for v0.2.0; v0.3.0 may expose a constructor kwarg so deployments with custom auth-context echo headers can extend the list.

## Design decisions

- **Only the stored/replayed copy is stripped** — matches the issue's "Decisions" section. The handler intended its `Set-Cookie` for the first caller, so the first response goes out with the originals. Replay must not leak them.
- **Frozenset of lowercase bytes** — ASGI delivers bytes already lowercased per spec; one `.lower()` per check stays O(1) without per-call decode/encode.
- **DESIGN.md is the canonical home for the rationale** — code carries pointers to it rather than duplicating the threat model in three places.

## Test plan

- [x] `pytest -m "not redis"` — 146 passed locally
- [x] Full suite with redis service container + coverage gate — 171 passed locally, total coverage 96.09%
- [x] Integration: first response carries `Set-Cookie`/`Authorization`/`WWW-Authenticate`; replay does not; safe headers + custom X-* survive
- [x] Unit: parametrized over the entire denylist (typo in any one entry fails loudly)
- [x] Unit: `Set-Cookie` (mixed case), `SET-COOKIE` (upper) both stripped
- [x] Unit: every denylist entry is lowercase (a capitalized entry would silently never match)