### PR TITLE
feat(security): hash idempotency keys in logs + structured log context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Idempotency keys are never written to logs in raw form. Log records
+  carry a truncated 12-hex-char hash and structured `extra` fields
+  (`key_hash`, `fingerprint`, `outcome`, `status`) for incident
+  correlation. See `docs/DESIGN.md` ("Logging — keys hashed, hot path
+  silent") for the per-outcome log levels and the field contract. (#22)
 - Strip volatile response headers (`Set-Cookie`, `Authorization`,
   `WWW-Authenticate`, `Proxy-Authenticate`, `Cookie`) and
   connection-level headers (`Connection`, `Keep-Alive`,

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -236,6 +236,47 @@ Hard-coded for v0.2.0. v0.3.0 may expose a constructor kwarg
 (`volatile_headers=[...]`) so deployments with custom headers
 (e.g. proprietary auth-context echoes) can extend the list.
 
+## Logging — keys hashed, hot path silent
+
+**Status: v0.2.0.**
+
+Applications routinely use user-controlled identifiers (order IDs,
+user emails, session tokens) as idempotency keys. Writing them to
+centralized logs (Datadog, ELK, Splunk) creates PII retention beyond
+the application's own controls. The middleware therefore hashes every
+key before emitting any log record, and includes it as a structured
+`key_hash` field alongside `fingerprint` and `outcome` for incident
+correlation.
+
+- **Hash function** — HMAC-SHA256 when `secret=` is configured for
+  fingerprinting, plain SHA-256 otherwise. Reusing the same secret
+  avoids a second config knob; a log-reader without the secret can't
+  recompute the hash of a guessed key. Rotate `IDEMP_SECRET` on
+  incident — secret compromise enables both fingerprint forgery and
+  log-hash recomputation.
+- **Truncation** — 12 hex chars (48 bits). Collision-resistant for
+  correlation within a typical retention window (birthday at ~2^24
+  keys), not a primary key and not reversible to recover the source.
+- **What gets logged** — `MISMATCH` (WARNING; potential probe or
+  client bug), `IN_FLIGHT` (INFO; normal concurrency), `StoreError`,
+  handler exceptions, and the no-response 500 path. `CREATED` /
+  `REPLAY` are silent — they're the hot path and would drown other
+  signals. Validation paths (400, 413, passthrough) are the access
+  log's responsibility.
+- **Structured fields** land on `LogRecord` via `extra=`, so
+  structlog / python-json-logger consumers get them as JSON keys:
+  - `key_hash` — always present.
+  - `fingerprint` — 12-hex truncation of the body fingerprint
+    (present on `MISMATCH` and `IN_FLIGHT`).
+  - `outcome` — the `AcquireOutcome` value (`mismatch`, `in_flight`).
+  - `status` — HTTP status code as string (`"409"`, `"422"`, `"500"`).
+  - `exc_type` — exception class name (handler-exception path only).
+- **No `exc_info=True`** on the handler-exception path — a downstream
+  handler may raise with the raw key in its message, and the
+  formatter would render the traceback unredacted. The exception
+  type lands in `exc_type` for triage; the surrounding ASGI server
+  is the right home for full traces.
+
 ## Why msgpack over JSON
 
 _To be written during v0.1.0._

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import logging
 from typing import TYPE_CHECKING, ClassVar
 
@@ -11,6 +13,7 @@ from .fingerprint import compute_fingerprint
 from .types import (
     AcquireOutcome,
     CachedResponse,
+    Fingerprint,
     IdempotencyKey,
 )
 
@@ -66,6 +69,33 @@ def _strip_volatile_headers(
     return tuple(
         (name, value) for name, value in headers if name.lower() not in _VOLATILE_HEADER_DENYLIST
     )
+
+
+_LOG_HASH_HEX_LEN = 12
+
+
+def _hash_for_log(value: bytes, secret: bytes | None) -> str:
+    h = hmac.new(secret, value, hashlib.sha256) if secret is not None else hashlib.sha256(value)
+    return h.hexdigest()[:_LOG_HASH_HEX_LEN]
+
+
+def _log_context(
+    key: IdempotencyKey,
+    secret: bytes | None,
+    *,
+    fingerprint: Fingerprint | None = None,
+    outcome: AcquireOutcome | None = None,
+    status: int | None = None,
+) -> dict[str, str]:
+    """Structured ``extra=`` payload — keeps raw keys out of logs."""
+    ctx: dict[str, str] = {"key_hash": _hash_for_log(key.encode(), secret)}
+    if fingerprint is not None:
+        ctx["fingerprint"] = fingerprint[:_LOG_HASH_HEX_LEN]
+    if outcome is not None:
+        ctx["outcome"] = outcome.value
+    if status is not None:
+        ctx["status"] = str(status)
+    return ctx
 
 
 class IdempotencyMiddleware:
@@ -202,6 +232,16 @@ class IdempotencyMiddleware:
             return
 
         if result.outcome is AcquireOutcome.IN_FLIGHT:
+            logger.info(
+                "concurrent request for in-flight Idempotency-Key; responding 409",
+                extra=_log_context(
+                    key,
+                    self._secret,
+                    fingerprint=fingerprint,
+                    outcome=result.outcome,
+                    status=409,
+                ),
+            )
             await self._send_plain_response(
                 send,
                 status=409,
@@ -209,7 +249,18 @@ class IdempotencyMiddleware:
             )
             return
 
-        # MISMATCH
+        # MISMATCH — same key, different body. May indicate a probe or
+        # a client bug; log at WARNING so ops can correlate.
+        logger.warning(
+            "Idempotency-Key reused with a different body; responding 422",
+            extra=_log_context(
+                key,
+                self._secret,
+                fingerprint=fingerprint,
+                outcome=result.outcome,
+                status=422,
+            ),
+        )
         await self._send_plain_response(
             send,
             status=422,
@@ -226,11 +277,18 @@ class IdempotencyMiddleware:
         interceptor = _ResponseInterceptor(send)
         try:
             await self.app(scope, replay, interceptor)
-        except Exception:
+        except Exception as exc:
+            # Don't log ``exc_info=True`` — a downstream handler may
+            # raise with the raw key in its message; the formatted
+            # traceback would defeat the no-PII-in-logs guarantee.
+            # Operators get the exception class via structured context;
+            # the surrounding ASGI server logs the full trace.
             logger.warning(
-                "exception inside intercepted handler for key=%r; releasing slot",
-                key,
-                exc_info=True,
+                "exception inside intercepted handler; releasing slot",
+                extra={
+                    **_log_context(key, self._secret),
+                    "exc_type": type(exc).__name__,
+                },
             )
             await self.store.release(key)
             raise
@@ -244,8 +302,8 @@ class IdempotencyMiddleware:
             # Handler returned without emitting http.response.start —
             # synthesize a 500 so the wire contract holds.
             logger.warning(
-                "handler returned without sending http.response.start for key=%r; emitting 500",
-                key,
+                "handler returned without sending http.response.start; emitting 500",
+                extra=_log_context(key, self._secret, status=500),
             )
             await self.store.release(key)
             await self._send_plain_response(
@@ -279,9 +337,9 @@ class IdempotencyMiddleware:
             await self.store.complete(key, cached, ttl=self.completed_ttl)
         except StoreError:
             logger.warning(
-                "store.complete raised StoreError for key=%r; serving "
-                "uncached response with Idempotency-Stored: false",
-                key,
+                "store.complete raised StoreError; serving uncached "
+                "response with Idempotency-Stored: false",
+                extra=_log_context(key, self._secret),
             )
             extra_headers = [(b"idempotency-stored", b"false")]
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,411 @@
+"""Logging-side guarantees: raw idempotency keys must never leak."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from fastapi_idempotency import (
+    Fingerprint,
+    IdempotencyKey,
+    IdempotencyMiddleware,
+    InMemoryStore,
+    StoreError,
+)
+from fastapi_idempotency.middleware import (
+    _LOG_HASH_HEX_LEN,
+    _hash_for_log,
+    _log_context,
+)
+from fastapi_idempotency.types import AcquireOutcome
+
+if TYPE_CHECKING:
+    from starlette.types import Receive, Scope, Send
+
+
+# Unit: ``_hash_for_log`` and ``_log_context``  -----------------------------
+
+
+def test_hash_for_log_returns_12_hex_chars() -> None:
+    digest = _hash_for_log(b"some-key", secret=None)
+
+    assert len(digest) == _LOG_HASH_HEX_LEN == 12
+    assert all(c in "0123456789abcdef" for c in digest)
+
+
+def test_hash_for_log_known_answer_sha256() -> None:
+    """Pin to a precomputed SHA-256 prefix so a future swap to a
+    different hash function (e.g., MD5) fails loudly even if length
+    and determinism survive."""
+    digest = _hash_for_log(b"known-input", secret=None)
+
+    assert digest == "27ae49c070b1"
+
+
+def test_hash_for_log_is_deterministic() -> None:
+    """Log correlation depends on same input producing same hash."""
+    a = _hash_for_log(b"order-42", secret=None)
+    b = _hash_for_log(b"order-42", secret=None)
+
+    assert a == b
+
+
+def test_hash_for_log_changes_with_input() -> None:
+    a = _hash_for_log(b"order-42", secret=None)
+    b = _hash_for_log(b"order-43", secret=None)
+
+    assert a != b
+
+
+def test_hash_for_log_with_secret_differs_from_plain() -> None:
+    """HMAC mode prevents a log-reader from recomputing the hash of a
+    guessed key without the secret."""
+    plain = _hash_for_log(b"order-42", secret=None)
+    hmac_h = _hash_for_log(b"order-42", secret=b"server-secret")
+
+    assert plain != hmac_h
+
+
+def test_hash_for_log_different_secrets_differ() -> None:
+    a = _hash_for_log(b"order-42", secret=b"secret-A")
+    b = _hash_for_log(b"order-42", secret=b"secret-B")
+
+    assert a != b
+
+
+def test_log_context_minimal_has_only_key_hash() -> None:
+    ctx = _log_context(IdempotencyKey("k"), secret=None)
+
+    assert set(ctx) == {"key_hash"}
+
+
+def test_log_context_with_fingerprint_and_outcome() -> None:
+    ctx = _log_context(
+        IdempotencyKey("k"),
+        secret=None,
+        fingerprint=Fingerprint("0" * 64),
+        outcome=AcquireOutcome.MISMATCH,
+    )
+
+    assert ctx["key_hash"] != ""
+    assert ctx["fingerprint"] == "0" * _LOG_HASH_HEX_LEN
+    assert ctx["outcome"] == "mismatch"
+
+
+def test_log_context_never_includes_raw_key() -> None:
+    """Whatever the future shape of the context dict, the raw key bytes
+    must never appear in any value."""
+    key = IdempotencyKey("super-secret-order-id-12345")
+    ctx = _log_context(
+        key,
+        secret=None,
+        fingerprint=Fingerprint("a" * 64),
+        outcome=AcquireOutcome.CREATED,
+    )
+
+    for value in ctx.values():
+        assert "super-secret" not in value
+
+
+# Integration: middleware log paths  ----------------------------------------
+
+
+async def _drive_request(receive: Receive) -> None:
+    while True:
+        message = await receive()
+        if message["type"] != "http.request":
+            break
+        if not message.get("more_body", False):
+            break
+
+
+async def echo_200_app(_scope: Scope, receive: Receive, send: Send) -> None:
+    await _drive_request(receive)
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"text/plain")],
+        },
+    )
+    await send({"type": "http.response.body", "body": b"ok"})
+
+
+_SENSITIVE_KEY = "order-user-pii-9999"
+
+
+def _key_appears_in_records(
+    caplog_records: list[logging.LogRecord],
+    raw_key: str,
+) -> bool:
+    """A leak check: raw key bytes must not appear in any log message,
+    args, exc_info, or extra-derived fields."""
+    for record in caplog_records:
+        if raw_key in record.getMessage():
+            return True
+        if raw_key in str(record.__dict__):
+            return True
+    return False
+
+
+async def test_mismatch_logs_warning_with_hashed_key(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    middleware = IdempotencyMiddleware(echo_200_app, InMemoryStore(), secret=None)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        with caplog.at_level(logging.WARNING, logger="fastapi_idempotency.middleware"):
+            await client.post(
+                "/",
+                headers={"Idempotency-Key": _SENSITIVE_KEY},
+                content=b"a",
+            )
+            await client.post(
+                "/",
+                headers={"Idempotency-Key": _SENSITIVE_KEY},
+                content=b"b",
+            )
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("different body" in r.getMessage() for r in warnings)
+    assert not _key_appears_in_records(caplog.records, _SENSITIVE_KEY)
+    # Structured extra fields present on the MISMATCH log.
+    mismatch_record = next(r for r in warnings if "different body" in r.getMessage())
+    assert mismatch_record.key_hash  # type: ignore[attr-defined]
+    assert mismatch_record.outcome == "mismatch"  # type: ignore[attr-defined]
+    assert mismatch_record.status == "422"  # type: ignore[attr-defined]
+
+
+async def test_in_flight_logs_info_with_hashed_key(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Concurrent 409 path logs at INFO with structured context.
+
+    Two requests race: the first holds the slot via an ``asyncio.Event``
+    until the second has had its acquire return IN_FLIGHT.
+    """
+    proceed = asyncio.Event()
+
+    async def slow_app(_scope: Scope, receive: Receive, send: Send) -> None:
+        await _drive_request(receive)
+        await proceed.wait()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            },
+        )
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    middleware = IdempotencyMiddleware(slow_app, InMemoryStore(), secret=None)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        with caplog.at_level(logging.INFO, logger="fastapi_idempotency.middleware"):
+            first = asyncio.create_task(
+                client.post(
+                    "/",
+                    headers={"Idempotency-Key": _SENSITIVE_KEY},
+                    content=b"x",
+                ),
+            )
+            # Let the first request acquire the slot.
+            await asyncio.sleep(0.05)
+            second = await client.post(
+                "/",
+                headers={"Idempotency-Key": _SENSITIVE_KEY},
+                content=b"x",
+            )
+            proceed.set()
+            await first
+
+    assert second.status_code == 409
+    info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+    inflight_record = next(r for r in info_records if "concurrent request" in r.getMessage())
+    assert inflight_record.key_hash  # type: ignore[attr-defined]
+    assert inflight_record.outcome == "in_flight"  # type: ignore[attr-defined]
+    assert inflight_record.status == "409"  # type: ignore[attr-defined]
+    assert not _key_appears_in_records(caplog.records, _SENSITIVE_KEY)
+
+
+async def test_store_error_logs_warning_with_hashed_key(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class FailingCompleteStore:
+        def __init__(self) -> None:
+            self._inner = InMemoryStore()
+
+        async def acquire(self, key, fingerprint, ttl):  # type: ignore[no-untyped-def]
+            return await self._inner.acquire(key, fingerprint, ttl)
+
+        async def get(self, key):  # type: ignore[no-untyped-def]
+            return await self._inner.get(key)
+
+        async def complete(self, key, response, ttl):  # type: ignore[no-untyped-def]
+            msg = "store down"
+            raise StoreError(msg)
+
+        async def release(self, key):  # type: ignore[no-untyped-def]
+            return await self._inner.release(key)
+
+    middleware = IdempotencyMiddleware(
+        echo_200_app,
+        FailingCompleteStore(),
+        secret=None,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        with caplog.at_level(logging.WARNING, logger="fastapi_idempotency.middleware"):
+            response = await client.post(
+                "/",
+                headers={"Idempotency-Key": _SENSITIVE_KEY},
+                content=b"a",
+            )
+
+    assert response.status_code == 200
+    store_record = next(r for r in caplog.records if "StoreError" in r.getMessage())
+    assert store_record.key_hash  # type: ignore[attr-defined]
+    assert not _key_appears_in_records(caplog.records, _SENSITIVE_KEY)
+
+
+async def test_no_response_handler_logs_warning_with_hashed_key(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The synthesized-500 path (handler returned without sending start)
+    must also hash the key — parallel to the handler-exception path."""
+
+    async def silent_app(_scope: Scope, receive: Receive, _send: Send) -> None:
+        await _drive_request(receive)
+        # Returns without calling send(...).
+
+    middleware = IdempotencyMiddleware(silent_app, InMemoryStore(), secret=None)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        with caplog.at_level(logging.WARNING, logger="fastapi_idempotency.middleware"):
+            response = await client.post(
+                "/",
+                headers={"Idempotency-Key": _SENSITIVE_KEY},
+                content=b"x",
+            )
+
+    assert response.status_code == 500
+    rec = next(r for r in caplog.records if "without sending http.response.start" in r.getMessage())
+    assert rec.key_hash  # type: ignore[attr-defined]
+    assert rec.status == "500"  # type: ignore[attr-defined]
+    assert not _key_appears_in_records(caplog.records, _SENSITIVE_KEY)
+
+
+async def test_created_and_replay_do_not_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Hot path (CREATED + REPLAY) emits no logs — high-volume noise control."""
+    middleware = IdempotencyMiddleware(echo_200_app, InMemoryStore(), secret=None)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        with caplog.at_level(logging.DEBUG, logger="fastapi_idempotency.middleware"):
+            await client.post(  # CREATED
+                "/",
+                headers={"Idempotency-Key": "kk"},
+                content=b"a",
+            )
+            await client.post(  # REPLAY
+                "/",
+                headers={"Idempotency-Key": "kk"},
+                content=b"a",
+            )
+
+    middleware_records = [r for r in caplog.records if r.name == "fastapi_idempotency.middleware"]
+    assert middleware_records == []
+
+
+async def test_handler_exception_logs_with_hashed_key_no_raw_leak(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def boom_app(_scope: Scope, receive: Receive, _send: Send) -> None:
+        await _drive_request(receive)
+        msg = "handler boom"
+        raise RuntimeError(msg)
+
+    middleware = IdempotencyMiddleware(boom_app, InMemoryStore(), secret=None)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        with (
+            caplog.at_level(
+                logging.WARNING,
+                logger="fastapi_idempotency.middleware",
+            ),
+            pytest.raises((httpx.RemoteProtocolError, RuntimeError)),
+        ):
+            await client.post(
+                "/",
+                headers={"Idempotency-Key": _SENSITIVE_KEY},
+                content=b"x",
+            )
+
+    exc_record = next(
+        r for r in caplog.records if "exception inside intercepted handler" in r.getMessage()
+    )
+    assert exc_record.key_hash  # type: ignore[attr-defined]
+    assert exc_record.exc_type == "RuntimeError"  # type: ignore[attr-defined]
+    assert not _key_appears_in_records(caplog.records, _SENSITIVE_KEY)
+
+
+async def test_hmac_secret_changes_logged_hash(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Verify the security property: same key under different secrets
+    produces different log hashes — log readers can't recompute hashes
+    without the secret."""
+    captures: dict[bytes | None, str] = {}
+    for secret in (None, b"secret-A", b"secret-B"):
+        store = InMemoryStore()
+        middleware = IdempotencyMiddleware(echo_200_app, store, secret=secret)
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=middleware),
+            base_url="http://testserver",
+        ) as client:
+            caplog.clear()
+            with caplog.at_level(
+                logging.WARNING,
+                logger="fastapi_idempotency.middleware",
+            ):
+                # Trigger MISMATCH to force a log emission.
+                await client.post(
+                    "/",
+                    headers={"Idempotency-Key": _SENSITIVE_KEY},
+                    content=b"a",
+                )
+                await client.post(
+                    "/",
+                    headers={"Idempotency-Key": _SENSITIVE_KEY},
+                    content=b"b",
+                )
+
+        mismatch = next(r for r in caplog.records if "different body" in r.getMessage())
+        captures[secret] = mismatch.key_hash  # type: ignore[attr-defined]
+
+    assert captures[None] != captures[b"secret-A"]
+    assert captures[b"secret-A"] != captures[b"secret-B"]


### PR DESCRIPTION
Closes #22

## Summary

Applications routinely use user-controlled identifiers (order IDs, user emails, session tokens) as idempotency keys. `logger.warning("...key=%r", key)` writes them to centralized logs (Datadog, ELK, Splunk) where retention often outlives the application. This PR hashes every key before logging and replaces the unstructured messages with structured `extra=` payloads for incident correlation.

- **`_hash_for_log(value, secret) -> str`** — HMAC-SHA256 when `secret=` is configured for fingerprinting (issue #20), plain SHA-256 otherwise. Truncated to 12 hex chars (48 bits — collision-resistant for correlation, not reversible).
- **`_log_context(key, secret, *, fingerprint, outcome, status) -> dict[str, str]`** — builds the structured payload (`key_hash`, optional `fingerprint`, `outcome`, `status`, `exc_type`). Lands on `LogRecord` via `extra=`; structlog / python-json-logger consumers get the fields as JSON keys.
- **5 log call sites updated**: the existing three (`StoreError`, handler exception, no-response 500) plus two new ones — `MISMATCH` at `WARNING` (potential probe / client bug) and `IN_FLIGHT` at `INFO` (normal concurrency). The hot path (`CREATED` / `REPLAY`) stays silent — high volume would drown other signals.
- **No `exc_info=True`** on the handler-exception path. A downstream handler may raise with the raw key in its message (`raise ValueError(f"bad order {key}")`); the formatted traceback would defeat the no-PII guarantee. Operators get `exc_type` for triage; the surrounding ASGI server still logs the full trace.

Full design rationale and field contract in `docs/DESIGN.md` ("Logging — keys hashed, hot path silent").

## Workflow

- Two review rounds with **4 agents** (security correctness, test rigor, architecture, comment / commit-content adequacy — the 4th lens was added after PR #37 to systematically catch comment duplication).
- Iter 1: 8 / 6.5 / 8 / 7. The 4th-lens reviewer flagged the same WHY repeated across constant comment + function docstring + DESIGN.md. Both inline duplicates deleted.
- Iter 2: 10 / 9 / 9 / 9 (average 9.25). Two cheap polishes (assert `status` on 409 / 422 records, assert `exc_type == "RuntimeError"` on exception record).

## Test plan

- [x] `pytest -m "not redis"` — 162 passed locally
- [x] Full suite with redis service container + coverage gate — 187 passed locally, total coverage 96.22%
- [x] Known-answer SHA-256 test pins `b"known-input" → 27ae49c070b1` (catches algorithm swap)
- [x] Integration via `caplog`: MISMATCH / IN_FLIGHT / StoreError / no-response 500 / handler exception all log with `key_hash` and no raw key in any record field
- [x] CREATED + REPLAY emit zero log records at DEBUG-capture level
- [x] Same key under different secrets produces different log hashes