### PR TITLE
feat(middleware): opt-in require_key=True mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `require_key=True` opt-in mode on `IdempotencyMiddleware`. With it
+  enabled, non-safe methods (POST/PATCH/PUT/DELETE) that arrive
+  without an `Idempotency-Key` header get `400 Bad Request` instead of
+  passing through. Default stays `False` (v0.1.0 pass-through);
+  payment APIs and other side-effect-heavy services should opt in.
+  Safe methods (GET/HEAD/OPTIONS) are unaffected. (#23)
 - Streaming response pass-through (#18). FastAPI / Starlette
   `StreamingResponse` (and any ASGI app emitting `more_body=True` on
   the first body chunk) now flows through the middleware live instead

--- a/README.md
+++ b/README.md
@@ -68,6 +68,25 @@ The middleware fails at construction (`KeyError` from `os.environ[...]`)
 if the variable isn't set — fail-fast at deploy is preferred over a
 runtime surprise.
 
+#### Enforcing the header (`require_key=True`)
+
+By default the middleware is opt-in: requests without an
+`Idempotency-Key` pass through to the handler. Payment APIs and other
+side-effect-heavy services usually want to enforce the header instead:
+
+```python
+app.add_middleware(
+    IdempotencyMiddleware,
+    store=InMemoryStore(),
+    secret=os.environ["IDEMP_SECRET"].encode(),
+    require_key=True,
+)
+```
+
+With `require_key=True`, a non-safe method (POST/PATCH/PUT/DELETE)
+arriving without the header responds `400 Bad Request` instead. Safe
+methods (GET/HEAD/OPTIONS) are unaffected.
+
 #### Insecure opt-out (tests / migration only)
 
 `secret=None` explicitly disables HMAC and falls back to v0.1.0's plain
@@ -175,6 +194,7 @@ the `Idempotency-Key` header. Outcomes:
 | Handler returned 5xx | Slot released; a retry will run the handler again. |
 | Handler returned a streaming response (`StreamingResponse`, SSE, file download) | Forwarded live; not cached. Slot released, retries run the handler again. |
 | Chunked-transfer body exceeds `max_body_bytes` | `413 Content Too Large`; handler not invoked, no slot created. |
+| Non-safe method with no header, when `require_key=True` | `400 Bad Request`; handler not invoked. (Pass-through with `require_key=False`, the default.) |
 | Storage failed after a successful response, or any other path that won't replay on retry | `Idempotency-Stored: false` header on the response |
 
 The `Idempotency-Stored: false` header is a union signal: it appears

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -122,6 +122,7 @@ class IdempotencyMiddleware:
         in_flight_ttl: float = 30.0,
         completed_ttl: float = 86_400.0,
         max_body_bytes: int | None = None,
+        require_key: bool = False,
     ) -> None:
         if isinstance(secret, _Missing):
             msg = (
@@ -137,6 +138,7 @@ class IdempotencyMiddleware:
         self.in_flight_ttl = in_flight_ttl
         self.completed_ttl = completed_ttl
         self.max_body_bytes = max_body_bytes
+        self.require_key = require_key
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
@@ -149,6 +151,14 @@ class IdempotencyMiddleware:
 
         key_value = self._extract_key(scope)
         if key_value is None:
+            if self.require_key:
+                method = scope["method"]
+                await self._send_plain_response(
+                    send,
+                    status=400,
+                    message=f"Idempotency-Key header required for {method} requests",
+                )
+                return
             await self.app(scope, receive, send)
             return
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -153,6 +153,156 @@ async def test_post_without_key_passes_through_to_handler() -> None:
     assert response.content == b"hello"
 
 
+async def test_require_key_default_off_missing_key_passes_through() -> None:
+    """Regression: ``require_key=False`` (default) preserves v0.1.0
+    pass-through behavior when the header is absent."""
+    invocations = 0
+
+    async def counting_app(scope: Scope, receive: Receive, send: Send) -> None:
+        nonlocal invocations
+        invocations += 1
+        await echo_app(scope, receive, send)
+
+    middleware = IdempotencyMiddleware(counting_app, InMemoryStore(), secret=None)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post("/", content=b"hello")
+
+    assert response.status_code == 200
+    assert response.content == b"hello"
+    assert invocations == 1
+
+
+async def test_require_key_true_missing_key_returns_400() -> None:
+    """``require_key=True`` + missing header on a non-safe method → 400."""
+    invocations = 0
+
+    async def counting_app(scope: Scope, receive: Receive, send: Send) -> None:
+        nonlocal invocations
+        invocations += 1
+        await echo_app(scope, receive, send)
+
+    middleware = IdempotencyMiddleware(
+        counting_app,
+        InMemoryStore(),
+        secret=None,
+        require_key=True,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post("/", content=b"hello")
+
+    assert response.status_code == 400
+    assert response.text == "Idempotency-Key header required for POST requests"
+    assert invocations == 0
+
+
+async def test_require_key_true_present_key_runs_normal_flow() -> None:
+    """``require_key=True`` + header present → normal CREATED → REPLAY."""
+    store = InMemoryStore()
+    middleware = IdempotencyMiddleware(
+        echo_app,
+        store,
+        secret=None,
+        require_key=True,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        first = await client.post(
+            "/",
+            headers={"Idempotency-Key": "abc"},
+            content=b"hi",
+        )
+        replay = await client.post(
+            "/",
+            headers={"Idempotency-Key": "abc"},
+            content=b"hi",
+        )
+
+    assert first.status_code == 200
+    assert replay.headers.get("idempotent-replayed") == "true"
+
+
+async def test_require_key_true_safe_methods_pass_through() -> None:
+    """GET / HEAD / OPTIONS are never intercepted, regardless of
+    ``require_key``."""
+    middleware = IdempotencyMiddleware(
+        echo_app,
+        InMemoryStore(),
+        secret=None,
+        require_key=True,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        get_response = await client.get("/")
+        head_response = await client.head("/")
+        options_response = await client.options("/")
+
+    assert get_response.status_code == 200
+    assert head_response.status_code == 200
+    assert options_response.status_code == 200
+
+
+async def test_require_key_true_empty_header_falls_to_invalid_not_missing() -> None:
+    """Empty-string header → ``_is_valid_key`` branch (400 "invalid
+    Idempotency-Key"), not the ``require_key`` branch. Pins the
+    contract: missing != malformed."""
+    middleware = IdempotencyMiddleware(
+        echo_app,
+        InMemoryStore(),
+        secret=None,
+        require_key=True,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/",
+            headers={"Idempotency-Key": ""},
+            content=b"x",
+        )
+
+    assert response.status_code == 400
+    assert response.text == "invalid Idempotency-Key"
+
+
+async def test_require_key_true_400_message_quotes_actual_method() -> None:
+    """The 400 message echoes the request method so the client knows
+    which path needs the header (PATCH/PUT/DELETE not just POST)."""
+    middleware = IdempotencyMiddleware(
+        echo_app,
+        InMemoryStore(),
+        secret=None,
+        require_key=True,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        patch_response = await client.patch("/", content=b"x")
+        delete_response = await client.delete("/")
+
+    assert patch_response.status_code == 400
+    assert "PATCH" in patch_response.text
+    assert delete_response.status_code == 400
+    assert "DELETE" in delete_response.text
+
+
 async def test_non_http_scope_passes_through() -> None:
     """Lifespan / websocket scopes should reach the wrapped app untouched."""
     seen_scopes: list[str] = []


### PR DESCRIPTION
Closes #23

## Summary

Missing `Idempotency-Key` on a non-safe method (POST/PATCH/PUT/DELETE) used to pass through to the handler. That's right for opt-in scenarios, but payment APIs and other side-effect-heavy services want enforcement instead.

- `IdempotencyMiddleware(..., require_key=True)` rejects non-safe requests without the header at `400 Bad Request` (message echoes the method, e.g. `"Idempotency-Key header required for PATCH requests"`). Handler not invoked, no slot created.
- Default stays `require_key=False` — v0.1.0 pass-through behavior preserved.
- Safe methods (GET/HEAD/OPTIONS) are never affected by the flag.

Tests pin: default off, `True` + missing → 400, `True` + present → CREATED → REPLAY normal flow, safe methods unaffected under `require_key=True`, message echoes actual method on PATCH/DELETE, and empty-string header falls to the existing "invalid Idempotency-Key" branch (not the "missing" one — pins missing-vs-malformed contract).

Reviewed under the four-lens batch (security, tests, architecture, comment / commit-content adequacy). Average 9.75 on iter 1; final polish closed the only nit (empty-header + `require_key=True` clarity test).

Out of scope for v0.2.0: per-route override (`require_key` on specific routes only) — deferred to v0.4.0 ergonomics work.

## Test plan

- [x] `pytest -m "not redis"` — 168 passed locally
- [x] Full suite with redis service container + coverage gate — 192+ passed locally, total coverage 96.26%
- [x] Default `require_key=False` regression: existing 167+ tests pass unchanged.