### PR TITLE
release: v0.2.0a1 pre-release polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,58 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Security
-
-- Idempotency keys are never written to logs in raw form. Log records
-  carry a truncated 12-hex-char hash and structured `extra` fields
-  (`key_hash`, `fingerprint`, `outcome`, `status`) for incident
-  correlation. See `docs/DESIGN.md` ("Logging — keys hashed, hot path
-  silent") for the per-outcome log levels and the field contract. (#22)
-- Strip volatile response headers (`Set-Cookie`, `Authorization`,
-  `WWW-Authenticate`, `Proxy-Authenticate`, `Cookie`) and
-  connection-level headers (`Connection`, `Keep-Alive`,
-  `Transfer-Encoding`, `Upgrade`, `Trailer`) before caching a
-  response. Previously the cache stored every header from the first
-  response verbatim and re-emitted them on replay — a session-theft
-  primitive in shared-store deployments where two requests share an
-  `Idempotency-Key`. The first caller still receives the handler's
-  original headers untouched; only the stored copy is filtered. Carried
-  over from v0.1.0; documented in `docs/DESIGN.md` ("Volatile response
-  headers stripped before caching"). (#21)
-
-### Changed
-
-- **BREAKING** (pre-1.0): `IdempotencyMiddleware(...)` now requires a
-  `secret=` keyword argument. Pass `secret=os.environ['IDEMP_SECRET']
-  .encode()` to enable HMAC-SHA256 request fingerprints (recommended
-  for any shared-store deployment), or `secret=None` to explicitly opt
-  into the v0.1.0 plain-SHA-256 fallback. Omitting the kwarg raises
-  `ValueError` at construction — no silent insecure default. Two
-  deployments sharing a store must use the same secret; different
-  secrets produce different fingerprints (#20).
+## [0.2.0a1] - 2026-05-14
 
 ### Added
 
-- `require_key=True` opt-in mode on `IdempotencyMiddleware`. With it
-  enabled, non-safe methods (POST/PATCH/PUT/DELETE) that arrive
-  without an `Idempotency-Key` header get `400 Bad Request` instead of
-  passing through. Default stays `False` (v0.1.0 pass-through);
-  payment APIs and other side-effect-heavy services should opt in.
-  Safe methods (GET/HEAD/OPTIONS) are unaffected. (#23)
-- Streaming response pass-through (#18). FastAPI / Starlette
-  `StreamingResponse` (and any ASGI app emitting `more_body=True` on
-  the first body chunk) now flows through the middleware live instead
-  of being buffered into memory. Streamed responses carry an
-  `Idempotency-Stored: false` header so retries know they won't replay,
-  and the in-flight slot is released — a stream cannot be cached.
-  Detection defers `http.response.start` until the first body chunk
-  so the header can be injected before start hits the wire.
-  Non-streaming responses keep the v0.1.0 caching/replay behavior
-  unchanged. The `Idempotency-Stored: false` header now carries a
-  union meaning ("response will not replay on retry"): emitted both
-  for streaming pass-through and for the v0.1.0 storage-failure path.
-- `RedisStore` — distributed `Store` backend backed by Redis (#17).
-  Atomic `acquire` via a single Lua `EVAL` so concurrent workers cannot
+- `RedisStore` — distributed `Store` backend backed by Redis. Atomic
+  `acquire` via a single Lua `EVAL` so concurrent workers cannot
   double-claim a key; `get` / `complete` / `release` are straightforward
   HSET/HGET/DEL paths. Requires the new `[redis]` extra
   (`pip install fastapi-idempotency[redis]`); `RedisStore` is exposed
@@ -66,30 +20,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the redis-py dependency. Defense-in-depth Python-side `is_expired`
   filter on `get` and `complete` covers the sub-millisecond race
   between `PEXPIRE` and `HGET`.
+- Streaming response pass-through. FastAPI / Starlette
+  `StreamingResponse` (and any ASGI app emitting `more_body=True` on
+  the first body chunk) now flows through the middleware live instead
+  of being buffered into memory. Streamed responses carry an
+  `Idempotency-Stored: false` header so retries know they won't replay,
+  and the in-flight slot is released — a stream cannot be cached. The
+  header now carries a union meaning ("response will not replay on
+  retry"): emitted for streaming pass-through and for the v0.1.0
+  storage-failure path.
+- `require_key=True` opt-in mode on `IdempotencyMiddleware`. With it
+  enabled, non-safe methods (POST/PATCH/PUT/DELETE) without an
+  `Idempotency-Key` header get `400 Bad Request` instead of passing
+  through. Default stays `False` (v0.1.0 pass-through behavior).
 - msgpack record codec (`stores._serde`) with a v1 envelope, schema
   versioning, and bounded payload size — used by `RedisStore` to
   serialize `IdempotencyRecord` to bytes.
-- Cross-store conformance suite (`tests/test_stores_conformance.py`) —
-  parametrized over both backends so any Store-protocol drift between
-  `InMemoryStore` and `RedisStore` (or future implementations) is
-  caught by one test run. Covers acquire/get/complete/release
-  classification, identity preservation, state-machine edges, single-
-  process concurrency (`asyncio.gather` of 10 coros), and TTL expiry
-  under `asyncio.sleep`. Slow tests carry `@pytest.mark.slow`; redis
-  variants carry `@pytest.mark.redis`.
-- Cross-process concurrent-acquire test
-  (`tests/test_stores_redis_concurrent.py`): N OS processes via
-  `ProcessPoolExecutor(spawn)` with a `Manager().Barrier` so all
-  workers race simultaneously — the distributed-locking property that
-  justifies the Redis dependency.
+- Cross-store conformance suite parametrized over both backends so any
+  drift between `InMemoryStore` and `RedisStore` (or future
+  implementations) is caught by one test run. Covers classification,
+  identity preservation, state-machine edges, single-process
+  concurrency, and TTL expiry under `asyncio.sleep`. Plus a
+  cross-process concurrent-acquire test via `ProcessPoolExecutor` —
+  the distributed-locking property that justifies the Redis dependency.
 - `REDIS_URL` env var in `tests/conftest.py` bypasses testcontainers
   for CI service containers and broken-Docker-bridge hosts; defaults
   to DB 15 to keep `FLUSHDB` blast radius off operators' DB 0.
-- `REDIS_TESTS_REQUIRED=1` flips the redis-tests-skipped path into a
-  hard fail (used by the new `check-redis` CI job).
 
 ### Changed
 
+- **BREAKING** (pre-1.0): `IdempotencyMiddleware(...)` now requires a
+  `secret=` keyword argument. Pass
+  `secret=os.environ['IDEMP_SECRET'].encode()` to enable HMAC-SHA256
+  request fingerprints, or `secret=None` to explicitly opt into the
+  v0.1.0 plain-SHA-256 fallback. Omitting the kwarg raises
+  `ValueError` at construction — no silent insecure default. Two
+  deployments sharing a store must use the same secret.
 - CI matrix now runs the full test suite (including `@pytest.mark.redis`
   and `@pytest.mark.slow`) against a Redis service container on every
   Python version (3.10–3.13). The 95% coverage gate fires on every
@@ -100,20 +66,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Chunked-transfer requests (no `Content-Length`) whose body exceeds
   `max_body_bytes` now respond `413 Content Too Large` instead of
-  bubbling out as an unhandled `RequestTooLargeError` (which the ASGI
-  server reported as 500). The handler is not invoked and no
-  idempotency record is created. The `Content-Length` pre-check
-  pass-through behavior is unchanged (#19).
+  bubbling out as an unhandled `RequestTooLargeError`. The handler is
+  not invoked and no idempotency record is created.
 - The internal request-body replay no longer raises `RuntimeError` on
   the second `receive()` call. Subsequent calls now forward to the
   original ASGI `receive`, so apps that listen for `http.disconnect`
   during streaming (e.g. Starlette's `StreamingResponse` background
-  task) work correctly (#18).
+  task) work correctly.
 - `InMemoryStore.complete` now raises `StoreError` on expired records
   (matching `RedisStore` and the `Store` protocol contract). Previously
   it silently overwrote the expired in-flight slot with a fresh
-  `COMPLETED` record, masking the `in_flight_ttl` tuning signal
-  operators are supposed to see (#17).
+  `COMPLETED` record, masking the `in_flight_ttl` tuning signal.
+
+### Security
+
+- Idempotency keys are never written to logs in raw form. Log records
+  carry a truncated 12-hex-char hash and structured `extra` fields
+  (`key_hash`, `fingerprint`, `outcome`, `status`) for incident
+  correlation. Caveat under `secret=None`: log hashes are not
+  unlinkable — see `docs/DESIGN.md` ("Logging — keys hashed, hot path
+  silent") for per-outcome log levels, the field contract, and the
+  HMAC-vs-plain-SHA-256 caveat.
+- Strip volatile response headers (`Set-Cookie`, `Authorization`,
+  `WWW-Authenticate`, `Proxy-Authorization`, `Proxy-Authenticate`,
+  `Cookie`) and connection-level headers (`Connection`, `Keep-Alive`,
+  `Transfer-Encoding`, `Upgrade`, `Trailer`) before caching. Previously
+  the cache stored every header verbatim and re-emitted them on
+  replay — a session-theft primitive in shared-store deployments. The
+  first caller still receives the handler's original headers
+  untouched; only the stored copy is filtered.
 
 ## [0.1.0] - 2026-04-30
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Status
 
-**Pre-release / experimental.** The public API is not stable; expect breaking changes before v0.2.0. Do not use in production yet.
+**Pre-release / experimental.** The public API is not stable and may break before v1.0. Not for production use yet. See Roadmap below for the v0.2.0 pre-release pipeline.
 
 ## Quickstart
 
@@ -91,7 +91,10 @@ methods (GET/HEAD/OPTIONS) are unaffected.
 
 `secret=None` explicitly disables HMAC and falls back to v0.1.0's plain
 SHA-256. Acceptable in tests; **not** safe for any shared-store
-deployment.
+deployment. Side effect: the log `key_hash` is then plain SHA-256, so
+a log reader with a candidate-key list (e.g. user IDs, order numbers)
+can recompute hashes and re-identify entries. Set a secret to get
+HMAC-based, unlinkable log hashes.
 
 #### Secret rotation
 
@@ -211,7 +214,7 @@ in-buffer fence is the only defense when the header is absent.
 
 ## Roadmap
 
-- **v0.1.0** — minimal working version: in-memory store, middleware core, fingerprint, two-phase TTL, replay path, basic error handling. Publish to TestPyPI.
-- **v0.2.0** — production-ready: Redis backend, `409 Conflict` on concurrent requests, `422` on body mismatch, streaming pass-through, full CI matrix (3.10–3.13), PyPI release via Trusted Publisher.
-- **v0.3.0** — ergonomics: lifecycle hooks (`on_replay`, `on_conflict`, `on_mismatch`), per-route config, per-user scoping, benchmarks.
-- **v0.4.0** — polish: full docs site, cookbook (payments, webhooks), release-notes automation.
+- **v0.1.0** — minimal working version: in-memory store, middleware core, fingerprint, two-phase TTL, replay path, basic error handling. Published to TestPyPI.
+- **v0.2.0** (in pre-release pipeline) — Redis backend, HMAC fingerprint (`secret=` required), streaming pass-through, volatile-header stripping, `require_key`, 413 on chunked overflow, key-hashing in logs, full CI matrix (3.10–3.13). Cutting `0.2.0a1 → 0.2.0rc1 → 0.2.0` to TestPyPI; not yet on real PyPI.
+- **v0.3.0** — production hardening: configurable volatile-header denylist, lifecycle hooks (`on_replay`, `on_conflict`, `on_mismatch`), per-route config, key scoping, metrics, SECURITY.md, PyPI release via Trusted Publisher.
+- **v0.4.0** — polish: docs site, cookbook (payments, webhooks), release-notes automation.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2,11 +2,36 @@
 
 This document records the reasoning behind non-obvious choices in `fastapi-idempotency`. Each section covers one decision: the context, the options considered, the choice, and the trade-offs accepted.
 
-> Status: placeholder. Sections are filled in as each version lands; the tag under each heading marks when it becomes authoritative.
+> Each section is tagged with the version in which it became authoritative. Sections tagged "planned for vN" describe decisions ratified but not yet implemented.
 
 ## Which response statuses are cacheable
 
-_To be written during v0.2.0._
+**Status: v0.2.0.**
+
+- **2xx, 3xx, 4xx** are cached — they reflect a deterministic handler
+  outcome that a retry would reach again. The replay path emits the
+  same body and headers (minus the volatile-header denylist).
+  - **3xx redirect caveat**: a `Location` header carrying a presigned
+    URL, OAuth `state` parameter, or other single-use token will be
+    re-emitted byte-for-byte on every replay within `completed_ttl`.
+    The right shape is to return a stable redirect target and let the
+    token-mint sit behind it; if a single-use redirect really is the
+    response, the client should omit `Idempotency-Key` on that route,
+    or the route should be excluded from the middleware (per-route
+    config lands in v0.3.0). Adding `Location` to the volatile
+    denylist would silently break the common case of stable
+    redirects, so the trade-off lands on the handler.
+- **5xx is *not* cached.** A 5xx is treated as a transient failure:
+  the slot is released and a retry runs the handler fresh. Caching
+  it would freeze the failure into every retry for `completed_ttl`,
+  which is precisely the wrong behaviour. The threshold lives in
+  `IdempotencyMiddleware.FIRST_SERVER_ERROR_STATUS` (= 500).
+- **Streaming responses are not cached** (see "Streaming response
+  pass-through" below). They're forwarded live with
+  `Idempotency-Stored: false` so a client knows the slot won't replay.
+- **Synthesized middleware responses (400, 409, 413, 422)** are not
+  cached because they are produced by the middleware itself, not by
+  the wrapped handler — there is nothing to replay.
 
 ## Two-phase TTL for the `in_flight` state
 
@@ -163,7 +188,7 @@ The middleware can't cache a streaming response — by definition the
 body is produced incrementally, often larger than memory can buffer
 (SSE feeds, file downloads, long-poll). Buffering would either OOM
 the worker or delay the first byte until the stream finishes,
-defeating the point of streaming. Issue #18 chose to **forward live
+defeating the point of streaming. v0.2.0 chose to **forward live
 and skip caching**: the slot is released, the response carries
 `Idempotency-Stored: false`, and retries run the handler again.
 
@@ -250,10 +275,16 @@ correlation.
 
 - **Hash function** — HMAC-SHA256 when `secret=` is configured for
   fingerprinting, plain SHA-256 otherwise. Reusing the same secret
-  avoids a second config knob; a log-reader without the secret can't
-  recompute the hash of a guessed key. Rotate `IDEMP_SECRET` on
-  incident — secret compromise enables both fingerprint forgery and
-  log-hash recomputation.
+  avoids a second config knob.
+  - Under HMAC, a log reader without the secret cannot recompute the
+    hash of a guessed key — this is the security property.
+  - Under plain SHA-256 (`secret=None`), the log hash is **not**
+    unlinkable: a log reader with a list of candidate keys (e.g. user
+    IDs, order numbers) can recompute their hashes and re-identify
+    log entries. `secret=None` is the v0.1.0 fallback for tests and
+    migration; production deployments should always set a secret.
+  - Rotate `IDEMP_SECRET` on incident — secret compromise enables
+    both fingerprint forgery and log-hash recomputation.
 - **Truncation** — 12 hex chars (48 bits). Collision-resistant for
   correlation within a typical retention window (birthday at ~2^24
   keys), not a primary key and not reversible to recover the source.
@@ -279,8 +310,39 @@ correlation.
 
 ## Why msgpack over JSON
 
-_To be written during v0.1.0._
+**Status: v0.2.0.**
+
+`IdempotencyRecord.response.body` is `bytes` and `headers` is
+`tuple[tuple[bytes, bytes], ...]`. JSON has no native bytes type — a
+JSON-based codec must base64-encode every body and every header value
+(~33% size overhead plus encode/decode CPU on every read/write). On a
+1 MiB body that's 350 KiB of avoidable storage and ~3 ms of CPU per
+round-trip; on a Redis-backed deployment with a 24 h `completed_ttl`,
+that compounds across millions of cached records.
+
+msgpack handles bytes natively (the `bin` type), preserves tuples vs
+lists (relevant for the headers shape), and round-trips deterministically
+when fed the same input. The codec is wrapped in a v1 envelope
+(`{"v": 1, "data": ...}`) so a future schema change can ship a v2
+decoder without breaking already-stored v1 records.
+
+Pickle was ruled out at design time: it's a remote-code-execution
+sink on untrusted bytes, which is exactly what a compromised Redis
+becomes. msgpack with `strict_map_key=True` + bounded `max_bin_len`
+/ `max_str_len` / `max_array_len` / `max_map_len` is the inverse —
+attacker-controlled bytes can't allocate beyond the configured caps,
+and an extra explicit `isinstance` validation pass on the decoded
+dict catches type-confusion attempts (e.g. `key` arriving as `int`,
+`body` as `str`, header pairs as 3-tuples that would unpack
+silently).
 
 ## Key scoping (`scope_factory`)
 
-_To be written during v0.3.0._
+**Status: planned for v0.3.0.** Not yet implemented.
+
+The current key-extraction reads `Idempotency-Key` from the request
+headers. Multi-tenant deployments often want to scope the key by
+something else — tenant ID, authenticated user, route prefix — so
+two tenants sharing the wire-level header don't collide. `scope_factory`
+will be a callable `(scope) -> bytes` injected into the middleware that
+prefixes the raw header value before the store sees it.

--- a/src/fastapi_idempotency/__init__.py
+++ b/src/fastapi_idempotency/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     # Static-checker re-export — runtime import is lazy via __getattr__.
     from .stores.redis import RedisStore as RedisStore
 
-__version__ = "0.1.0"
+__version__ = "0.2.0a1"
 
 __all__ = [
     "ConflictError",

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -42,17 +42,19 @@ class _Missing:
 _SECRET_NOT_SET = _Missing()
 
 
-# Headers dropped from the cached response — prevents session/credential
-# leak on REPLAY. See ``docs/DESIGN.md`` ("Volatile response headers")
-# for the threat model and denylist split.
+# Stripped from the cached response — see ``docs/DESIGN.md``
+# ("Volatile response headers stripped before caching") for the
+# threat model and the identity / connection-level split.
 _VOLATILE_HEADER_DENYLIST: frozenset[bytes] = frozenset(
     {
+        # Identity / credential headers
         b"set-cookie",
         b"authorization",
         b"proxy-authorization",
         b"www-authenticate",
         b"proxy-authenticate",
         b"cookie",
+        # Hop-by-hop (RFC 7230 §6.1, RFC 9110 §7.6.1)
         b"connection",
         b"keep-alive",
         b"transfer-encoding",
@@ -65,7 +67,6 @@ _VOLATILE_HEADER_DENYLIST: frozenset[bytes] = frozenset(
 def _strip_volatile_headers(
     headers: tuple[tuple[bytes, bytes], ...],
 ) -> tuple[tuple[bytes, bytes], ...]:
-    """Drop denylisted headers (case-insensitive) for caching."""
     return tuple(
         (name, value) for name, value in headers if name.lower() not in _VOLATILE_HEADER_DENYLIST
     )
@@ -259,8 +260,9 @@ class IdempotencyMiddleware:
             )
             return
 
-        # MISMATCH — same key, different body. May indicate a probe or
-        # a client bug; log at WARNING so ops can correlate.
+        # MISMATCH — log at WARNING: a key reused with a different body
+        # is either a buggy client or a probe. See DESIGN.md
+        # ("Logging — keys hashed, hot path silent").
         logger.warning(
             "Idempotency-Key reused with a different body; responding 422",
             extra=_log_context(
@@ -288,11 +290,9 @@ class IdempotencyMiddleware:
         try:
             await self.app(scope, replay, interceptor)
         except Exception as exc:
-            # Don't log ``exc_info=True`` — a downstream handler may
-            # raise with the raw key in its message; the formatted
-            # traceback would defeat the no-PII-in-logs guarantee.
-            # Operators get the exception class via structured context;
-            # the surrounding ASGI server logs the full trace.
+            # No ``exc_info=True``: downstream exceptions may carry the
+            # raw key in their message, and the traceback would render
+            # it unredacted. See DESIGN.md ("Logging — keys hashed").
             logger.warning(
                 "exception inside intercepted handler; releasing slot",
                 extra={

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -2,4 +2,4 @@ from fastapi_idempotency import __version__
 
 
 def test_version_exported() -> None:
-    assert __version__ == "0.1.0"
+    assert __version__ == "0.2.0a1"


### PR DESCRIPTION
## Summary

Pre-release polish bundle landing on `release/v0.2.0` ahead of the `0.2.0a1` alpha tag.

- Bumps `__version__` → `0.2.0a1` (PEP 440 alpha); `test_package.py` synced.
- CHANGELOG reorganized to canonical Keep-a-Changelog order under dated `[0.2.0a1] - 2026-05-14`, with `[Unreleased]` stub above. Log-hash caveat trimmed to a one-line pointer to DESIGN.md (no rationale duplication).
- DESIGN.md fills three v0.2.0 placeholders — cacheable statuses (with 3xx presigned-URL caveat), msgpack-vs-JSON, scope_factory marked planned-v0.3.0. Placeholder banner reworded for status-tag convention.
- README Status aligned with Roadmap; stability horizon clarified to v1.0; `secret=None` block carries the log-hash recompute attack at the config point.
- middleware comments carry inline WHY at the suppression site (`exc_info=True`, MISMATCH log level), pointing to DESIGN.md for the full treatment.
- Volatile-header denylist split into `Identity / credential` and `Hop-by-hop (RFC 7230 §6.1, RFC 9110 §7.6.1)` with citations.

Closes #25.

## Test plan

- [x] CI matrix green across 3.10–3.13 (Redis service container)
- [x] `uv run pytest -q` locally: 168 passed, 25 redis-skipped on hosts without Docker
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run mypy src/` clean
- [x] `__version__` import path returns `"0.2.0a1"`