### PR TITLE
chore(release): bump version to 0.2.0rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0rc1] - 2026-05-14
+
+Release candidate — no functional changes from `0.2.0a1`. Validates the
+`pre-release → rc → final` publish pipeline against TestPyPI before
+cutting `0.2.0`.
+
 ## [0.2.0a1] - 2026-05-14
 
 ### Added

--- a/src/fastapi_idempotency/__init__.py
+++ b/src/fastapi_idempotency/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     # Static-checker re-export — runtime import is lazy via __getattr__.
     from .stores.redis import RedisStore as RedisStore
 
-__version__ = "0.2.0a1"
+__version__ = "0.2.0rc1"
 
 __all__ = [
     "ConflictError",

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -2,4 +2,4 @@ from fastapi_idempotency import __version__
 
 
 def test_version_exported() -> None:
-    assert __version__ == "0.2.0a1"
+    assert __version__ == "0.2.0rc1"


### PR DESCRIPTION
## Summary

Bumps `__version__` → `0.2.0rc1`. No functional changes from `0.2.0a1` — release candidate cut to validate the `pre-release → rc → final` publish pipeline against TestPyPI before tagging `0.2.0`.

CHANGELOG carries a one-paragraph `[0.2.0rc1]` heading noting "no functional changes from `0.2.0a1`"; `test_package.py` synced to the new version.

## Test plan

- [x] CI matrix green across 3.10–3.13
- [x] `uv run pytest tests/test_package.py` passes locally
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run mypy src/` clean