### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-23
+
+Final 0.2.0 cut from rc1 after a security/architecture review pass.
+Three deltas vs `0.2.0rc1`; no other behavioral changes.
+
+### Fixed
+
+- `RedisStore.complete` now atomically re-checks the fingerprint inside
+  its Lua `EVAL`, closing a TOCTOU between Python's `HGET` and the
+  `EVAL` itself: an eviction + re-acquire by a different request
+  between those two RTTs now raises `StoreError` instead of silently
+  overwriting the fresh slot. The wider long-handler race (eviction +
+  re-acquire that happened *before* the `HGET`) is not closed; treat
+  `in_flight_ttl` as a correctness boundary (see README "Configuration
+  caveats"). The protocol-level fix lands in v0.3.0.
+
+### Removed
+
+- **BREAKING** (pre-1.0): `ConflictError` and `FingerprintMismatchError`
+  exports. Declared in v0.1.0 but never raised — the middleware signals
+  these conditions via `AcquireOutcome.IN_FLIGHT` / `MISMATCH` on the
+  `Store.acquire` return value and emits `409` / `422` directly.
+  Defensive `except IdempotencyError` (base) still catches everything
+  this library raises.
+
+### Documentation
+
+- README: new "Threat model" and "Configuration caveats" sections —
+  single-tenant scope, HMAC-required threat surfaces, store-access
+  attacker model, `in_flight_ttl` correctness boundary, `max_body_bytes`
+  DoS surface, `completed_ttl` replay window.
+
 ## [0.2.0rc1] - 2026-05-14
 
 Release candidate — no functional changes from `0.2.0a1`. Validates the

--- a/README.md
+++ b/README.md
@@ -212,6 +212,59 @@ pass through untouched (idempotency simply skipped). Chunked-transfer
 uploads (no `Content-Length`) over the limit get `413` instead — the
 in-buffer fence is the only defense when the header is absent.
 
+## Threat model
+
+The middleware deduplicates concurrent and retried requests on non-safe
+methods. It is **not** a substitute for authentication or authorization.
+Assumptions:
+
+- **No per-tenant key scoping.** Fingerprints cover
+  `(method, path, query, body)` only. Two users sending the same key
+  with the same request see the same cached response — the first
+  tenant's response leaks to the second. Multiplex tenants upstream
+  (per-tenant store, namespaced keys, custom `Store`).
+- **HMAC secret required for shared stores.** With `secret=None` the
+  fingerprint is plain SHA-256, so an attacker who controls a client
+  can probe via wire outcomes (`409` in-flight, `422` mismatch,
+  `Idempotent-Replayed: true` on match) to confirm which `(key, body)`
+  pairs the store holds. Setting `secret=` to a non-empty bytes value
+  closes the offline-forgery path; all workers sharing a store must
+  use the same secret. Bungled rotation (workers running with mixed
+  secrets simultaneously) silently bypasses dedupe — see the "Secret
+  rotation" note in the Quickstart.
+- **Store access implies response replay or injection.** A reader of
+  the store can replay any cached response by re-issuing the original
+  `(key, body)`. A writer can plant arbitrary responses via `HSET key
+  data <crafted msgpack>` (the middleware will serve them on `REPLAY`)
+  or force re-execution by deleting slots. Use Redis ACLs and
+  per-deployment namespaces.
+
+Deeper rationale and per-decision threat analysis in
+[`docs/DESIGN.md`](docs/DESIGN.md).
+
+## Configuration caveats
+
+Defaults that aren't safe in every deployment:
+
+- **`in_flight_ttl` must exceed handler p99.** If the in-flight slot
+  evicts while the handler is still running and a retry re-acquires
+  the slot with a different body, the long-running handler's
+  `complete()` may write into the wrong slot — either silently
+  overwriting the new record (`InMemoryStore`, or `RedisStore` when
+  the re-acquire happened before this worker's `HGET`) or surfacing
+  as `Idempotency-Stored: false` (`RedisStore` Lua fp-check fires).
+  Either way, treat `in_flight_ttl` as a correctness boundary, not a
+  tuning knob. The protocol-level fix (passing the original
+  fingerprint through `Store.complete`) lands in v0.3.0.
+- **`max_body_bytes=None` is a DoS surface.** Unbounded body
+  buffering lets an attacker hold a worker by sending a slow multi-GB
+  body. Set an explicit per-deployment limit for production. The
+  default tightens in v0.3.0.
+- **`completed_ttl` is both the dedupe window and the replay window.**
+  Default 24h. A leaked `Idempotency-Key` is replayable for as long
+  as `completed_ttl`; shorter windows lose dedupe coverage, longer
+  windows widen the replay-of-captured-request surface.
+
 ## Roadmap
 
 - **v0.1.0** — minimal working version: in-memory store, middleware core, fingerprint, two-phase TTL, replay path, basic error handling. Published to TestPyPI.

--- a/README.md
+++ b/README.md
@@ -268,6 +268,6 @@ Defaults that aren't safe in every deployment:
 ## Roadmap
 
 - **v0.1.0** — minimal working version: in-memory store, middleware core, fingerprint, two-phase TTL, replay path, basic error handling. Published to TestPyPI.
-- **v0.2.0** (in pre-release pipeline) — Redis backend, HMAC fingerprint (`secret=` required), streaming pass-through, volatile-header stripping, `require_key`, 413 on chunked overflow, key-hashing in logs, full CI matrix (3.10–3.13). Cutting `0.2.0a1 → 0.2.0rc1 → 0.2.0` to TestPyPI; not yet on real PyPI.
+- **v0.2.0** — Redis backend, HMAC fingerprint (`secret=` required), streaming pass-through, volatile-header stripping, `require_key`, 413 on chunked overflow, key-hashing in logs, full CI matrix (3.10–3.13). Cut as `0.2.0a1 → 0.2.0rc1 → 0.2.0`; the final tag absorbed a TOCTOU fix, a breaking dead-code removal, and the threat-model README sections directly (no intermediate rc2). Published to TestPyPI; not yet on real PyPI.
 - **v0.3.0** — production hardening: configurable volatile-header denylist, lifecycle hooks (`on_replay`, `on_conflict`, `on_mismatch`), per-route config, key scoping, metrics, SECURITY.md, PyPI release via Trusted Publisher.
 - **v0.4.0** — polish: docs site, cookbook (payments, webhooks), release-notes automation.

--- a/src/fastapi_idempotency/__init__.py
+++ b/src/fastapi_idempotency/__init__.py
@@ -15,8 +15,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from .errors import (
-    ConflictError,
-    FingerprintMismatchError,
     IdempotencyError,
     RequestTooLargeError,
     StoreError,
@@ -41,8 +39,6 @@ if TYPE_CHECKING:
 __version__ = "0.2.0rc1"
 
 __all__ = [
-    "ConflictError",
-    "FingerprintMismatchError",
     "IdempotencyError",
     "IdempotencyMiddleware",
     "InMemoryStore",

--- a/src/fastapi_idempotency/__init__.py
+++ b/src/fastapi_idempotency/__init__.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     # Static-checker re-export — runtime import is lazy via __getattr__.
     from .stores.redis import RedisStore as RedisStore
 
-__version__ = "0.2.0rc1"
+__version__ = "0.2.0"
 
 __all__ = [
     "IdempotencyError",

--- a/src/fastapi_idempotency/errors.py
+++ b/src/fastapi_idempotency/errors.py
@@ -7,14 +7,6 @@ class IdempotencyError(Exception):
     """Base class for every error raised by this package."""
 
 
-class ConflictError(IdempotencyError):
-    """A concurrent request already holds the in-flight slot for this key."""
-
-
-class FingerprintMismatchError(IdempotencyError):
-    """Same Idempotency-Key was reused with a different request body."""
-
-
 class StoreError(IdempotencyError):
     """The backing store failed (network, serialization, protocol error)."""
 

--- a/src/fastapi_idempotency/stores/redis.py
+++ b/src/fastapi_idempotency/stores/redis.py
@@ -101,21 +101,30 @@ return {'replay', existing_data}
 """
 
 
+# Atomic fp re-check closes the TOCTOU between Python's HGET and
+# this EVAL: an eviction + re-acquire by a different request between
+# the two RTTs yields error_reply rather than a silent overwrite.
+#
 #   KEYS: [1] full namespaced key
-#   ARGV: [1] new-record msgpack bytes, [2] ttl_ms (positive int)
-#   Returns: 'ok', or error_reply if the slot was evicted between
-#   Python's read and this call.
+#   ARGV: [1] expected fingerprint hex, [2] ttl_ms (positive int),
+#         [3] new-record msgpack bytes
+#   Returns: 'ok', or error_reply if the slot is missing / fp mismatches.
 _COMPLETE_LUA = """
 local key = KEYS[1]
-local data = ARGV[1]
+local expected_fp = ARGV[1]
 local ttl_ms = tonumber(ARGV[2])
+local data = ARGV[3]
 
 if not ttl_ms or ttl_ms <= 0 then
   return redis.error_reply('ttl_ms must be a positive integer')
 end
 
-if redis.call('EXISTS', key) == 0 then
+local stored_fp = redis.call('HGET', key, 'fp')
+if not stored_fp then
   return redis.error_reply('cannot complete unknown idempotency key')
+end
+if stored_fp ~= expected_fp then
+  return redis.error_reply('idempotency slot reclaimed by different request')
 end
 
 redis.call('HSET', key, 'state', 'completed', 'data', data)
@@ -174,7 +183,7 @@ class RedisStore:
         try:
             result = await self._acquire_script(
                 keys=[full_key],
-                args=[str(fingerprint), ttl_ms, new_data],
+                args=[fingerprint, ttl_ms, new_data],
             )
         except (RedisError, OSError) as exc:
             raise _wrap_redis_error("acquire", exc) from exc
@@ -214,12 +223,8 @@ class RedisStore:
         response: CachedResponse,
         ttl: float,
     ) -> None:
-        # 2-RTT (HGET + Lua): a TTL eviction + re-acquire between them
-        # would let us complete-overwrite a fresh slot's data. Bounded
-        # by in_flight_ttl tuning; harden in a future pass.
         full_key = self._key(key)
 
-        # Read to preserve identity (key, fingerprint, created_at).
         try:
             existing_data = await self.client.hget(full_key, "data")  # type: ignore[misc]
         except (RedisError, OSError) as exc:
@@ -230,8 +235,8 @@ class RedisStore:
             raise StoreError(msg)
 
         existing = decode_record(existing_data)
-        # Same Python-clock guard as ``get``: PEXPIRE may not have
-        # fired yet on a sub-millisecond race.
+        # Python-clock guard against the sub-ms PEXPIRE-vs-HGET race;
+        # the Lua below covers the eviction + re-acquire race separately.
         now = time.time()
         if existing.is_expired(now):
             msg = f"cannot complete unknown idempotency key: {key!r}"
@@ -249,7 +254,7 @@ class RedisStore:
         try:
             await self._complete_script(
                 keys=[full_key],
-                args=[new_data, ttl_ms],
+                args=[existing.fingerprint, ttl_ms, new_data],
             )
         except (RedisError, OSError) as exc:
             raise _wrap_redis_error("complete", exc) from exc

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -2,4 +2,4 @@ from fastapi_idempotency import __version__
 
 
 def test_version_exported() -> None:
-    assert __version__ == "0.2.0rc1"
+    assert __version__ == "0.2.0"

--- a/tests/test_stores_redis_integration.py
+++ b/tests/test_stores_redis_integration.py
@@ -13,9 +13,11 @@ Marked ``@pytest.mark.redis``. Two purposes:
 from __future__ import annotations
 
 import time
+from dataclasses import replace
 
 import pytest
 import redis.asyncio
+from redis.exceptions import ResponseError
 
 from fastapi_idempotency import (
     CachedResponse,
@@ -112,3 +114,112 @@ async def test_complete_raises_on_python_side_expired_record(
     response = CachedResponse(status_code=200, headers=(), body=b"")
     with pytest.raises(StoreError):
         await store.complete(key, response, ttl=3600.0)
+
+
+@pytest.mark.redis
+async def test_complete_lua_rejects_fp_mismatch(
+    redis_client: redis.asyncio.Redis,
+) -> None:
+    """The ``_COMPLETE_LUA`` script must refuse to overwrite a slot whose
+    stored fp differs from the expected fp the caller observed — the
+    eviction + re-acquire race that Python's HGET-then-EVAL window opens.
+
+    Drives the Lua directly with a stale ``expected_fp`` to simulate
+    worker A's view of the slot before worker B's re-acquire swapped it.
+    """
+    store = RedisStore(redis_client)
+    key = IdempotencyKey("fp-mismatch-reject")
+    full_key = store._key(key)
+
+    fresh = IdempotencyRecord(
+        key=key,
+        fingerprint=Fingerprint("fp_b"),
+        state=IdempotencyState.IN_FLIGHT,
+        created_at=time.time(),
+        expires_at=time.time() + 30.0,
+        response=None,
+    )
+    await redis_client.hset(
+        full_key,
+        mapping={
+            b"fp": b"fp_b",
+            b"state": b"in_flight",
+            b"data": encode_record(fresh),
+        },
+    )
+    await redis_client.pexpire(full_key, 60_000)
+
+    stale_data = encode_record(replace(fresh, fingerprint=Fingerprint("fp_a")))
+
+    with pytest.raises(ResponseError, match="reclaimed"):
+        await store._complete_script(
+            keys=[full_key],
+            args=["fp_a", 3600 * 1000, stale_data],
+        )
+
+    # Sanity: the fresh slot was not overwritten.
+    assert await redis_client.hget(full_key, "fp") == b"fp_b"
+    assert await redis_client.hget(full_key, "state") == b"in_flight"
+
+
+@pytest.mark.redis
+async def test_complete_full_path_rejects_eviction_and_reacquire(
+    redis_client: redis.asyncio.Redis,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end through ``RedisStore.complete``: an eviction + re-acquire
+    that lands between the Python-side HGET and the Lua EVAL raises
+    ``StoreError`` instead of silently overwriting the fresh slot.
+
+    Guards the Python glue (correct fp passed as ``expected_fp``) on top of
+    the Lua-only ``test_complete_lua_rejects_fp_mismatch``. A regression
+    that swaps arg order or passes the wrong fingerprint at the call site
+    would still pass the Lua test, but must fail this one.
+    """
+    store = RedisStore(redis_client)
+    key = IdempotencyKey("eviction-reacquire-e2e")
+    full_key = store._key(key)
+
+    original = IdempotencyRecord(
+        key=key,
+        fingerprint=Fingerprint("fp_a"),
+        state=IdempotencyState.IN_FLIGHT,
+        created_at=time.time(),
+        expires_at=time.time() + 30.0,
+        response=None,
+    )
+    await redis_client.hset(
+        full_key,
+        mapping={
+            b"fp": b"fp_a",
+            b"state": b"in_flight",
+            b"data": encode_record(original),
+        },
+    )
+    await redis_client.pexpire(full_key, 60_000)
+
+    real_hget = store.client.hget
+    swap_done = False
+
+    async def hget_then_swap(name: str, field: str) -> bytes | None:
+        nonlocal swap_done
+        result: bytes | None = await real_hget(name, field)
+        if not swap_done:
+            swap_done = True
+            reacquired = replace(original, fingerprint=Fingerprint("fp_b"))
+            await redis_client.hset(
+                full_key,
+                mapping={b"fp": b"fp_b", b"data": encode_record(reacquired)},
+            )
+        return result
+
+    monkeypatch.setattr(store.client, "hget", hget_then_swap)
+
+    response = CachedResponse(status_code=200, headers=(), body=b"")
+    with pytest.raises(StoreError):
+        await store.complete(key, response, ttl=3600.0)
+
+    monkeypatch.undo()
+    # fp_b's IN_FLIGHT slot survived intact — no silent overwrite.
+    assert await redis_client.hget(full_key, "fp") == b"fp_b"
+    assert await redis_client.hget(full_key, "state") == b"in_flight"

--- a/uv.lock
+++ b/uv.lock
@@ -461,11 +461,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -1006,15 +1006,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Final cut of `v0.2.0` from `0.2.0rc1`. Four atomic commits, no other behavioral changes vs rc1.

- **`fix(redis-store): close complete() TOCTOU by re-checking fp in Lua`** — `_COMPLETE_LUA` now atomically verifies `stored_fp == expected_fp` (the fp Python observed via `HGET`) before overwriting. An eviction + re-acquire by a different request between Python's HGET and the Lua EVAL raises `StoreError` instead of silently overwriting the fresh slot. Two integration tests added: Lua-isolation (`test_complete_lua_rejects_fp_mismatch`) and end-to-end via `monkeypatch.setattr(client, "hget", ...)` (`test_complete_full_path_rejects_eviction_and_reacquire`). The wider long-handler race (eviction + re-acquire that happened **before** the HGET) is not closed — protocol-level fix (passing fp through `Store.complete`) deferred to v0.3.0.
- **`refactor(errors)!: drop unused ConflictError and FingerprintMismatchError`** — declared in v0.1.0 but never raised; the middleware signals these conditions via `AcquireOutcome.IN_FLIGHT` / `MISMATCH` on `Store.acquire` and emits 409 / 422 directly. **BREAKING** vs rc1 (pre-1.0): `from fastapi_idempotency import ConflictError` snaps. Defensive `except IdempotencyError` (base) still catches everything this library raises.
- **`docs(readme): add threat model and configuration caveats sections`** — single-tenant key scope, HMAC-required threat surfaces (wire-side MISMATCH/REPLAY oracle in plain-SHA-256 mode, rotation downgrade), store-access attacker model (replay + injection via `HSET`), `in_flight_ttl` correctness boundary with per-backend race outcomes, `max_body_bytes=None` DoS surface, `completed_ttl` replay window.
- **`chore(release): bump version to 0.2.0`** — `__version__`, `test_package.py`, CHANGELOG `[0.2.0] - 2026-05-23` entry, README Roadmap line updated (no intermediate rc2 was cut).

Out of scope, deferred to v0.3.0:
- `Store.complete(key, fingerprint, response, ttl)` protocol change — only way to close the wider long-handler race in both backends.
- `InMemoryStore` parity with the Redis TOCTOU fix is not needed (asyncio.Lock makes the read+write atomic, no sub-RTT window exists); the shared long-handler race is the same protocol limitation as Redis.
- `max_body_bytes` default tightening (#26).
- Per-route / per-user key scoping (`scope_factory`).
- `Development Status :: 3 - Alpha` classifier stays — README Status section still says "Pre-release / experimental".

## Test plan

- [x] CI matrix green across 3.10–3.13 (Redis service container)
- [x] \`uv run pytest -q\` locally: 195 passed (full suite incl. \`@pytest.mark.redis\`)
- [x] \`uv run mypy src/\` clean
- [x] Build artifacts produced (\`python -m build\`): \`fastapi_idempotency-0.2.0.tar.gz\`, \`fastapi_idempotency-0.2.0-py3-none-any.whl\`
- [x] \`__version__\` import returns \`"0.2.0"\`
- [x] Integration test for fp-mismatch eviction race passes against real Redis