### PR TITLE
feat(store)!: close long-handler race via Store.complete(record, ...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Long-handler race: a handler outliving `in_flight_ttl` no longer
-  silently overwrites a slot re-acquired by a different request.
-  Both stores now fp-check the caller's record against the stored
-  slot inside their atomic section and raise `StoreError` on
-  mismatch. See `docs/DESIGN.md` ("Long-handler race closure") for
-  the scope of the closure and accepted residuals.
+- Long-handler race on `Store.complete`: a handler outliving
+  `in_flight_ttl` no longer silently overwrites a slot re-acquired
+  by a different request. Both stores fp-check the caller's record
+  against the stored slot inside their atomic section and raise
+  `StoreError` on mismatch. (The `Store.release` arm of the same
+  race is still open; see `docs/DESIGN.md` "Long-handler race
+  closure" for scope and residuals.)
 - `RedisStore.complete` is now a single round-trip (Lua `EVAL`
   only); the v0.2.0 Python-side `HGET` probe is gone.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** (pre-1.0): `Store.complete` signature is now
+  `complete(record, response, ttl)` where `record` is the in-flight
+  `IdempotencyRecord` returned by `acquire`. Third-party `Store`
+  implementations must update from the v0.2.0 shape
+  `complete(key, response, ttl)`. The middleware threads
+  `acquire`'s result through automatically; only custom integrations
+  are affected.
+
+### Fixed
+
+- Long-handler race: a handler outliving `in_flight_ttl` no longer
+  silently overwrites a slot re-acquired by a different request.
+  Both stores now fp-check the caller's record against the stored
+  slot inside their atomic section and raise `StoreError` on
+  mismatch. See `docs/DESIGN.md` ("Long-handler race closure") for
+  the scope of the closure and accepted residuals.
+- `RedisStore.complete` is now a single round-trip (Lua `EVAL`
+  only); the v0.2.0 Python-side `HGET` probe is gone.
+
 ## [0.2.0] - 2026-05-23
 
 Final 0.2.0 cut from rc1 after a security/architecture review pass.

--- a/README.md
+++ b/README.md
@@ -246,16 +246,17 @@ Deeper rationale and per-decision threat analysis in
 
 Defaults that aren't safe in every deployment:
 
-- **`in_flight_ttl` must exceed handler p99.** If the in-flight slot
-  evicts while the handler is still running and a retry re-acquires
-  the slot with a different body, the long-running handler's
-  `complete()` may write into the wrong slot — either silently
-  overwriting the new record (`InMemoryStore`, or `RedisStore` when
-  the re-acquire happened before this worker's `HGET`) or surfacing
-  as `Idempotency-Stored: false` (`RedisStore` Lua fp-check fires).
-  Either way, treat `in_flight_ttl` as a correctness boundary, not a
-  tuning knob. The protocol-level fix (passing the original
-  fingerprint through `Store.complete`) lands in v0.3.0.
+- **`in_flight_ttl` is a tuning signal, not a silent correctness
+  boundary.** If the in-flight slot evicts before the handler
+  finishes and a retry re-acquires the slot with a *different* body,
+  the original handler's `complete()` now raises `StoreError`
+  instead of overwriting the new tenant's record — the response is
+  delivered with `Idempotency-Stored: false`. Closed in v0.3.0 via
+  the `Store.complete(record, ...)` protocol; see `docs/DESIGN.md`
+  ("Long-handler race closure") for the closure mechanism and
+  accepted residuals. Set `in_flight_ttl` above handler p99 to keep
+  the race out of production traffic in the first place — but the
+  cross-tenant silent-overwrite risk is gone.
 - **`max_body_bytes=None` is a DoS surface.** Unbounded body
   buffering lets an attacker hold a worker by sending a slow multi-GB
   body. Set an explicit per-deployment limit for production. The
@@ -269,5 +270,5 @@ Defaults that aren't safe in every deployment:
 
 - **v0.1.0** — minimal working version: in-memory store, middleware core, fingerprint, two-phase TTL, replay path, basic error handling. Published to TestPyPI.
 - **v0.2.0** — Redis backend, HMAC fingerprint (`secret=` required), streaming pass-through, volatile-header stripping, `require_key`, 413 on chunked overflow, key-hashing in logs, full CI matrix (3.10–3.13). Cut as `0.2.0a1 → 0.2.0rc1 → 0.2.0`; the final tag absorbed a TOCTOU fix, a breaking dead-code removal, and the threat-model README sections directly (no intermediate rc2). Published to TestPyPI; not yet on real PyPI.
-- **v0.3.0** — production hardening: configurable volatile-header denylist, lifecycle hooks (`on_replay`, `on_conflict`, `on_mismatch`), per-route config, key scoping, metrics, SECURITY.md, PyPI release via Trusted Publisher.
+- **v0.3.0** — production hardening: long-handler race closure via `Store.complete(record, ...)` protocol, configurable volatile-header denylist, lifecycle hooks (`on_replay`, `on_conflict`, `on_mismatch`), per-route config, key scoping, metrics, SECURITY.md, PyPI release via Trusted Publisher.
 - **v0.4.0** — polish: docs site, cookbook (payments, webhooks), release-notes automation.

--- a/README.md
+++ b/README.md
@@ -246,17 +246,15 @@ Deeper rationale and per-decision threat analysis in
 
 Defaults that aren't safe in every deployment:
 
-- **`in_flight_ttl` is a tuning signal, not a silent correctness
-  boundary.** If the in-flight slot evicts before the handler
-  finishes and a retry re-acquires the slot with a *different* body,
-  the original handler's `complete()` now raises `StoreError`
-  instead of overwriting the new tenant's record — the response is
-  delivered with `Idempotency-Stored: false`. Closed in v0.3.0 via
-  the `Store.complete(record, ...)` protocol; see `docs/DESIGN.md`
-  ("Long-handler race closure") for the closure mechanism and
-  accepted residuals. Set `in_flight_ttl` above handler p99 to keep
-  the race out of production traffic in the first place — but the
-  cross-tenant silent-overwrite risk is gone.
+- **`in_flight_ttl` is a tuning signal.** If the in-flight slot
+  evicts before the handler finishes and a retry re-acquires the
+  slot with a *different* body, the original handler's `complete()`
+  now raises `StoreError` and the response is delivered with
+  `Idempotency-Stored: false` — no cross-tenant overwrite via
+  `complete`. (A symmetric `Store.release`-arm gap remains; see
+  `docs/DESIGN.md` "Long-handler race closure".) Set
+  `in_flight_ttl` above handler p99 to keep the race out of
+  production traffic.
 - **`max_body_bytes=None` is a DoS surface.** Unbounded body
   buffering lets an attacker hold a worker by sending a slow multi-GB
   body. Set an explicit per-deployment limit for production. The

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -212,7 +212,42 @@ the in-lock check below is brand new.
   stored `fp` field, fp-checks against the caller's `expected_fp`,
   and rewrites `state`/`data` atomically. The 2-RTT v0.2.0 pattern
   (Python-side `HGET` then Lua `EVAL`) is gone — there is no
-  Python-side window to race against anymore.
+  Python-side window where a different tenant could be swapped in.
+
+Both backends write the caller's `record` (not a re-decoded stored
+record) with `state`/`expires_at`/`response` overridden. The
+fp check makes this safe — a non-matching `record.fingerprint`
+never reaches the write — and it keeps the protocol contract
+short: "complete writes the in-flight record you got from
+`acquire` with three fields overridden."
+
+### Conformance requirements
+
+A third-party `Store.complete` implementation MUST, inside its
+atomic section:
+
+1. Check that the slot is present (backend-defined: server-side
+   eviction, Python-clock `is_expired`, etc.). Raise `StoreError`
+   if not.
+2. Compare the stored fingerprint against `record.fingerprint`.
+   Raise `StoreError` on mismatch.
+3. Persist the caller's `record.created_at`, not the stored
+   record's — under same-fp ABA the two may differ. Both shipped
+   backends rebuild from the caller's `record`; cross-backend
+   behavior then converges.
+
+All three constraints must hold before any state mutation.
+"Atomic section" here means any mechanism that serializes (1) +
+(2) + the subsequent write against concurrent `acquire` /
+`complete` / `release` on the same key — an in-process lock, a
+single Lua `EVAL`, a SERIALIZABLE transaction, a conditional
+update with a fingerprint predicate, etc. The two shipped
+backends use `asyncio.Lock` and single-EVAL Lua respectively.
+
+The conformance suite (`tests/test_stores_conformance.py`)
+enforces all three via `test_complete_rejects_fingerprint_mismatch`,
+`test_complete_raises_on_unknown_key`, and
+`test_complete_preserves_callers_created_at_under_same_fp_aba`.
 
 ### Trade-off: dropping the Python-clock guard on complete
 
@@ -231,14 +266,30 @@ record.
 
 ### What is not closed
 
-Same-fp ABA — eviction + re-acquire with an identical body — is
+**Same-fp ABA.** Eviction + re-acquire with an identical body is
 still possible. Both completions carry the same fp and write valid
-responses; the second wins on `data` (last-write-wins). Accepted as
-benign: both completions are retries of semantically the same
-request, so either response is correct. `created_at` is not a
-reliable audit field under this race — the two backends differ in
-which acquire-time it preserves — but no caller depends on it for
-correctness.
+responses; the second wins on `data` (last-write-wins). Both
+backends now preserve the *caller's* `created_at` (pinned by
+`test_complete_preserves_callers_created_at_under_same_fp_aba`).
+Accepted as benign under HMAC mode: both completions are retries
+of semantically the same request, so either response is correct.
+Under `secret=None` (the insecure mode documented in the
+HMAC-fingerprint section) an attacker who can guess the body can
+forge the same fp and race-acquire post-eviction to capture a
+target's response — yet another reason `secret=None` is for tests
+and one-off migration only.
+
+**The `Store.release` arm of the same race.** The fp guard sits on
+`complete`; `release` still wipes by key alone. The middleware
+calls `store.release(key)` on four paths — handler raises, handler
+returns 5xx, handler emits no `http.response.start`, streamed
+response pass-through — and any of them, when the original handler
+outlives `in_flight_ttl`, can delete a slot re-acquired by a
+different request. No cross-tenant response *leak* — but a
+cross-tenant *availability* failure: the new tenant's `complete`
+then sees an unknown key and delivers `Idempotency-Stored: false`.
+The symmetric closure (`release(record)` with fp check) is tracked
+for a follow-up; not in #44's scope.
 
 ### Protocol break
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -180,6 +180,76 @@ layer, not the source of truth for "is this expired".
   (`{namespace}:{key}`), so it is safe under Redis Cluster routing —
   no cross-slot operations.
 
+## Long-handler race closure
+
+**Status: v0.3.0.**
+
+`Store.complete` takes the in-flight `IdempotencyRecord` that
+`acquire` returned, not just the key. Stores fp-check the caller's
+`record.fingerprint` against what's currently stored inside their
+atomic section and raise `StoreError` on mismatch.
+
+The race this closes: handler A acquires the slot for `(key, fp_a)`
+and outlives `in_flight_ttl`. The slot evicts. Handler B re-acquires
+the same `key` with a different body (`fp_b`). Handler A finally
+finishes and calls `complete`. With the v0.2.0 protocol — which
+took only `(key, response, ttl)` — the slow handler's response
+would silently overwrite B's slot. A real cross-tenant integrity
+leak when keys collide across requests.
+
+v0.2.0's `RedisStore.complete` had partial coverage via a Lua-side
+`fp` re-check, but only inside the sub-RTT window between Python's
+`HGET` and the `EVAL`. The wider Python-side window before the
+`HGET` was still open. `InMemoryStore` had no protection at all —
+the in-lock check below is brand new.
+
+### What changed in each backend
+
+- `InMemoryStore.complete` compares `existing.fingerprint` against
+  the caller's `record.fingerprint` inside `asyncio.Lock`. The lock
+  makes the check TOCTOU-safe.
+- `RedisStore.complete` is now a single Lua `EVAL` that reads the
+  stored `fp` field, fp-checks against the caller's `expected_fp`,
+  and rewrites `state`/`data` atomically. The 2-RTT v0.2.0 pattern
+  (Python-side `HGET` then Lua `EVAL`) is gone — there is no
+  Python-side window to race against anymore.
+
+### Trade-off: dropping the Python-clock guard on complete
+
+The v0.2.0 `RedisStore.complete` ran a Python-clock `is_expired`
+check on the `HGET` result as defense-in-depth against the
+sub-millisecond race between `PEXPIRE` firing and the next `HGET`
+seeing the key. With the `HGET` gone, that check is gone too.
+Server-side `PEXPIRE` is now the only authority on whether the
+slot is alive for `complete`. The cost: a slot whose Python-clock
+`expires_at` has elapsed but whose `PEXPIRE` hasn't yet fired
+could in principle accept a `complete` and self-heal its
+`expires_at` to a future value. Since the fp must still match for
+the write to land, no cross-tenant leak survives — only a
+slightly-extended slot lifetime for the original handler's own
+record.
+
+### What is not closed
+
+Same-fp ABA — eviction + re-acquire with an identical body — is
+still possible. Both completions carry the same fp and write valid
+responses; the second wins on `data` (last-write-wins). Accepted as
+benign: both completions are retries of semantically the same
+request, so either response is correct. `created_at` is not a
+reliable audit field under this race — the two backends differ in
+which acquire-time it preserves — but no caller depends on it for
+correctness.
+
+### Protocol break
+
+The `Store.complete` signature change is **BREAKING** for
+third-party backends. Migration is mechanical: take a `record`
+parameter where you previously took `key`, and use `record.key` /
+`record.fingerprint` / `record.created_at` (and any other in-flight
+fields you need). The middleware threads `acquire`'s result
+through automatically — built-in stores required no caller-side
+changes beyond the protocol update itself.
+
 ## Streaming response pass-through
 
 **Status: v0.2.0.**

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -15,6 +15,7 @@ from .types import (
     CachedResponse,
     Fingerprint,
     IdempotencyKey,
+    IdempotencyRecord,
 )
 
 if TYPE_CHECKING:
@@ -221,7 +222,7 @@ class IdempotencyMiddleware:
         )
 
         if result.outcome is AcquireOutcome.CREATED:
-            await self._run_and_cache(scope, replay, send, key)
+            await self._run_and_cache(scope, replay, send, result.record)
             return
 
         if result.outcome is AcquireOutcome.REPLAY:
@@ -284,8 +285,9 @@ class IdempotencyMiddleware:
         scope: Scope,
         replay: Receive,
         send: Send,
-        key: IdempotencyKey,
+        record: IdempotencyRecord,
     ) -> None:
+        key = record.key
         interceptor = _ResponseInterceptor(send)
         try:
             await self.app(scope, replay, interceptor)
@@ -344,7 +346,7 @@ class IdempotencyMiddleware:
         )
         extra_headers: list[tuple[bytes, bytes]] = []
         try:
-            await self.store.complete(key, cached, ttl=self.completed_ttl)
+            await self.store.complete(record, cached, ttl=self.completed_ttl)
         except StoreError:
             logger.warning(
                 "store.complete raised StoreError; serving uncached "

--- a/src/fastapi_idempotency/store.py
+++ b/src/fastapi_idempotency/store.py
@@ -70,24 +70,27 @@ class Store(Protocol):
 
     async def complete(
         self,
-        key: IdempotencyKey,
+        record: IdempotencyRecord,
         response: CachedResponse,
         ttl: float,
     ) -> None:
         """Transition IN_FLIGHT → COMPLETED, persisting ``response`` for ``ttl`` seconds.
 
-        Preserves ``key``, ``fingerprint``, and ``created_at`` from the
-        in-flight record; overwrites ``state``, ``expires_at``, and
+        ``record`` is the in-flight record the caller received from
+        ``acquire`` (its ``CREATED`` result). The store uses
+        ``record.key`` / ``record.fingerprint`` / ``record.created_at``
+        verbatim and overwrites ``state``, ``expires_at``, and
         ``response``. The new ``expires_at`` is ``now + ttl`` (this
         ``ttl`` *replaces* any remaining acquire-phase TTL — eviction
         is reseated, not extended).
 
-        The caller must own the slot (i.e. previously received
-        ``CREATED`` from ``acquire``). If no record exists for ``key``
-        — or the existing record has expired — the store raises
-        :class:`StoreError`. This typically means the in-flight TTL
-        elapsed before the handler finished; tune ``in_flight_ttl``
-        upward if this fires in production.
+        If no record exists for ``record.key``, the stored record has
+        expired, or its fingerprint differs from ``record.fingerprint``,
+        the store raises :class:`StoreError`. The fingerprint check
+        closes the long-handler race: a handler that outruns
+        ``in_flight_ttl`` would otherwise silently overwrite a slot
+        re-acquired by a different request in the meantime. Tune
+        ``in_flight_ttl`` upward if this fires in production.
         """
         ...
 

--- a/src/fastapi_idempotency/store.py
+++ b/src/fastapi_idempotency/store.py
@@ -76,21 +76,22 @@ class Store(Protocol):
     ) -> None:
         """Transition IN_FLIGHT → COMPLETED, persisting ``response`` for ``ttl`` seconds.
 
-        ``record`` is the in-flight record the caller received from
-        ``acquire`` (its ``CREATED`` result). The store uses
-        ``record.key`` / ``record.fingerprint`` / ``record.created_at``
-        verbatim and overwrites ``state``, ``expires_at``, and
-        ``response``. The new ``expires_at`` is ``now + ttl`` (this
-        ``ttl`` *replaces* any remaining acquire-phase TTL — eviction
-        is reseated, not extended).
+        ``record`` must be the in-flight record the caller received
+        from ``acquire`` (the ``CREATED`` result) — treat it as an
+        opaque token, do not synthesize one. The store writes the
+        caller's record with ``state``, ``expires_at``, and
+        ``response`` overridden. The new ``expires_at`` is
+        ``now + ttl`` (this ``ttl`` *replaces* any remaining
+        acquire-phase TTL — eviction is reseated, not extended).
 
-        If no record exists for ``record.key``, the stored record has
-        expired, or its fingerprint differs from ``record.fingerprint``,
-        the store raises :class:`StoreError`. The fingerprint check
-        closes the long-handler race: a handler that outruns
-        ``in_flight_ttl`` would otherwise silently overwrite a slot
-        re-acquired by a different request in the meantime. Tune
-        ``in_flight_ttl`` upward if this fires in production.
+        Raises :class:`StoreError` if the slot is gone or its stored
+        fingerprint differs from ``record.fingerprint``. Both checks
+        must complete inside the same atomic section before any
+        write. Backends authoritatively define "slot is gone"
+        (server-side `PEXPIRE` for Redis, Python-clock
+        ``is_expired`` for in-memory). See ``docs/DESIGN.md``
+        ("Long-handler race closure") for rationale and conformance
+        requirements.
         """
         ...
 

--- a/src/fastapi_idempotency/stores/memory.py
+++ b/src/fastapi_idempotency/stores/memory.py
@@ -82,21 +82,20 @@ class InMemoryStore:
             now = time.time()
             existing = self._records.get(record.key)
             # Expired-but-not-yet-purged records count as gone (matches
-            # Redis PEXPIRE eviction). Must run inside ``self._lock`` —
-            # outside, a TOCTOU race could silent-overwrite a fresh slot.
+            # Redis PEXPIRE eviction).
             if existing is None or existing.is_expired(now):
                 raise StoreError(
                     f"cannot complete unknown idempotency key: {record.key!r}",
                 )
-            # Long-handler race: slot evicted, re-acquired by a different
-            # request, original handler now finishing. Reject instead of
-            # overwriting the new tenant's slot.
             if existing.fingerprint != record.fingerprint:
                 raise StoreError(
                     f"idempotency slot reclaimed by different request: {record.key!r}",
                 )
+            # Write the caller's record, not ``existing`` — keeps both
+            # backends symmetric under same-fp ABA. See DESIGN.md
+            # ("Long-handler race closure").
             self._records[record.key] = replace(
-                existing,
+                record,
                 state=IdempotencyState.COMPLETED,
                 expires_at=now + ttl,
                 response=response,

--- a/src/fastapi_idempotency/stores/memory.py
+++ b/src/fastapi_idempotency/stores/memory.py
@@ -74,21 +74,28 @@ class InMemoryStore:
 
     async def complete(
         self,
-        key: IdempotencyKey,
+        record: IdempotencyRecord,
         response: CachedResponse,
         ttl: float,
     ) -> None:
         async with self._lock:
             now = time.time()
-            existing = self._records.get(key)
+            existing = self._records.get(record.key)
             # Expired-but-not-yet-purged records count as gone (matches
             # Redis PEXPIRE eviction). Must run inside ``self._lock`` —
             # outside, a TOCTOU race could silent-overwrite a fresh slot.
             if existing is None or existing.is_expired(now):
                 raise StoreError(
-                    f"cannot complete unknown idempotency key: {key!r}",
+                    f"cannot complete unknown idempotency key: {record.key!r}",
                 )
-            self._records[key] = replace(
+            # Long-handler race: slot evicted, re-acquired by a different
+            # request, original handler now finishing. Reject instead of
+            # overwriting the new tenant's slot.
+            if existing.fingerprint != record.fingerprint:
+                raise StoreError(
+                    f"idempotency slot reclaimed by different request: {record.key!r}",
+                )
+            self._records[record.key] = replace(
                 existing,
                 state=IdempotencyState.COMPLETED,
                 expires_at=now + ttl,

--- a/src/fastapi_idempotency/stores/redis.py
+++ b/src/fastapi_idempotency/stores/redis.py
@@ -101,11 +101,9 @@ return {'replay', existing_data}
 """
 
 
-# Single-RTT complete: caller passes the fingerprint it acquired with,
-# Lua fp-checks against stored ``fp`` and rewrites ``state`` + ``data``
-# in one round-trip. Closes the long-handler race (eviction + re-acquire
-# by a different request) — without the fp guard the handler would
-# silently overwrite the new tenant's slot.
+# Single-RTT complete. fp-check + HSET + PEXPIRE in one EVAL —
+# see DESIGN.md ("Long-handler race closure") for why the caller's
+# fp is the guard.
 #
 #   KEYS: [1] full namespaced key
 #   ARGV: [1] expected fingerprint hex, [2] ttl_ms (positive int),

--- a/src/fastapi_idempotency/stores/redis.py
+++ b/src/fastapi_idempotency/stores/redis.py
@@ -101,9 +101,11 @@ return {'replay', existing_data}
 """
 
 
-# Atomic fp re-check closes the TOCTOU between Python's HGET and
-# this EVAL: an eviction + re-acquire by a different request between
-# the two RTTs yields error_reply rather than a silent overwrite.
+# Single-RTT complete: caller passes the fingerprint it acquired with,
+# Lua fp-checks against stored ``fp`` and rewrites ``state`` + ``data``
+# in one round-trip. Closes the long-handler race (eviction + re-acquire
+# by a different request) — without the fp guard the handler would
+# silently overwrite the new tenant's slot.
 #
 #   KEYS: [1] full namespaced key
 #   ARGV: [1] expected fingerprint hex, [2] ttl_ms (positive int),
@@ -219,42 +221,26 @@ class RedisStore:
 
     async def complete(
         self,
-        key: IdempotencyKey,
+        record: IdempotencyRecord,
         response: CachedResponse,
         ttl: float,
     ) -> None:
-        full_key = self._key(key)
-
-        try:
-            existing_data = await self.client.hget(full_key, "data")  # type: ignore[misc]
-        except (RedisError, OSError) as exc:
-            raise _wrap_redis_error("complete", exc) from exc
-
-        if existing_data is None:
-            msg = f"cannot complete unknown idempotency key: {key!r}"
-            raise StoreError(msg)
-
-        existing = decode_record(existing_data)
-        # Python-clock guard against the sub-ms PEXPIRE-vs-HGET race;
-        # the Lua below covers the eviction + re-acquire race separately.
+        full_key = self._key(record.key)
         now = time.time()
-        if existing.is_expired(now):
-            msg = f"cannot complete unknown idempotency key: {key!r}"
-            raise StoreError(msg)
 
         new_record = replace(
-            existing,
+            record,
             state=IdempotencyState.COMPLETED,
             expires_at=now + ttl,
             response=response,
         )
         new_data = encode_record(new_record)
-
         ttl_ms = int(ttl * 1000)
+
         try:
             await self._complete_script(
                 keys=[full_key],
-                args=[existing.fingerprint, ttl_ms, new_data],
+                args=[record.fingerprint, ttl_ms, new_data],
             )
         except (RedisError, OSError) as exc:
             raise _wrap_redis_error("complete", exc) from exc

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -251,7 +251,7 @@ async def test_store_error_logs_warning_with_hashed_key(
         async def get(self, key):  # type: ignore[no-untyped-def]
             return await self._inner.get(key)
 
-        async def complete(self, key, response, ttl):  # type: ignore[no-untyped-def]
+        async def complete(self, record, response, ttl):  # type: ignore[no-untyped-def]
             msg = "store down"
             raise StoreError(msg)
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -859,11 +859,11 @@ async def test_store_error_on_complete_adds_idempotency_stored_false_header() ->
 
         async def complete(
             self,
-            key: IdempotencyKey,
+            record: IdempotencyRecord,
             response: CachedResponse,
             ttl: float,
         ) -> None:
-            del key, response, ttl
+            del record, response, ttl
             msg = "simulated eviction"
             raise StoreError(msg)
 

--- a/tests/test_stores_conformance.py
+++ b/tests/test_stores_conformance.py
@@ -55,15 +55,19 @@ RESPONSE = CachedResponse(
 
 
 def _record(
+    *,
     key: IdempotencyKey = KEY,
     fingerprint: Fingerprint = FP,
-    *,
     ttl: float = 30.0,
 ) -> IdempotencyRecord:
-    """Synthesize an IN_FLIGHT record matching what ``acquire`` returns.
+    """Synthesize an IN_FLIGHT record for error-path tests only.
 
-    Used by tests that exercise ``complete`` without going through a real
-    ``acquire`` — e.g. error paths where the slot was never created.
+    The ``Store.complete`` contract says ``record`` is an opaque
+    token from ``acquire``. This helper deliberately bypasses that
+    contract to exercise error paths where no slot exists; do not
+    use it in tests that drive happy-path semantics. Keyword-only
+    because ``key`` and ``fingerprint`` are both str-flavoured
+    NewTypes — positional order errors don't type-check.
     """
     now = time.time()
     return IdempotencyRecord(
@@ -226,12 +230,9 @@ async def test_complete_raises_on_unknown_key(store: Store) -> None:
 
 
 async def test_complete_rejects_fingerprint_mismatch(store: Store) -> None:
-    """Long-handler race: the slot the caller acquired was released and
-    re-acquired by a different request before this ``complete`` fires.
-
-    Both backends must reject — otherwise the late ``complete`` would
-    silently overwrite the new tenant's slot with the original handler's
-    response.
+    """Both backends must reject when the stored fp differs from the
+    caller's record. Without this guard a late ``complete`` would
+    overwrite a slot already re-acquired by another request.
     """
     original = (await store.acquire(KEY, FP, ttl=30.0)).record
     await store.release(KEY)
@@ -240,11 +241,35 @@ async def test_complete_rejects_fingerprint_mismatch(store: Store) -> None:
     with pytest.raises(StoreError):
         await store.complete(original, RESPONSE, ttl=3600.0)
 
-    # The new tenant's slot survived intact — no silent overwrite.
     surviving = await store.get(KEY)
     assert surviving is not None
     assert surviving.fingerprint == Fingerprint("fp-other")
     assert surviving.state is IdempotencyState.IN_FLIGHT
+
+
+async def test_complete_preserves_callers_created_at_under_same_fp_aba(
+    store: Store,
+) -> None:
+    """Same-fp ABA: both backends persist the *caller's* ``created_at``.
+
+    Pinned cross-backend so the accepted residual stays observable and
+    consistent — without this, InMemory and Redis could silently diverge
+    on which acquire-time survives.
+    """
+    original = (await store.acquire(KEY, FP, ttl=30.0)).record
+    await store.release(KEY)
+    # Force a measurable gap so the second acquire's ``created_at``
+    # differs from the first — otherwise sub-microsecond ticks could
+    # mask a backend that silently picks the wrong timestamp.
+    await asyncio.sleep(0.01)
+    reacquired = (await store.acquire(KEY, FP, ttl=30.0)).record
+    assert reacquired.created_at > original.created_at
+
+    await store.complete(original, RESPONSE, ttl=3600.0)
+
+    stored = await store.get(KEY)
+    assert stored is not None
+    assert stored.created_at == original.created_at
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_stores_conformance.py
+++ b/tests/test_stores_conformance.py
@@ -385,6 +385,32 @@ async def test_complete_after_ttl_expires_raises(store: Store) -> None:
         await store.complete(acquired.record, RESPONSE, ttl=3600.0)
 
 
+@pytest.mark.slow
+async def test_complete_rejects_fp_mismatch_after_ttl_reacquire(store: Store) -> None:
+    """Full long-handler race via real TTL eviction.
+
+    Distinct from ``test_complete_rejects_fingerprint_mismatch`` (which
+    uses explicit ``release``) — this one drives the production scenario
+    end-to-end: A's slot evicts by TTL, B re-acquires with a different
+    fingerprint, A's late ``complete`` must raise rather than overwrite
+    B's slot. Catches a backend that handled ``release``-then-reacquire
+    correctly but mishandled TTL-eviction-then-reacquire — Redis's
+    PEXPIRE eviction is a different path from InMemory's lazy ``is_expired``
+    check, and both must converge on the same fp-mismatch verdict.
+    """
+    acquired = await store.acquire(KEY, FP, ttl=_TTL_S)
+    await asyncio.sleep(_TTL_WAIT_S)
+    await store.acquire(KEY, Fingerprint("fp-other"), ttl=30.0)
+
+    with pytest.raises(StoreError):
+        await store.complete(acquired.record, RESPONSE, ttl=3600.0)
+
+    surviving = await store.get(KEY)
+    assert surviving is not None
+    assert surviving.fingerprint == Fingerprint("fp-other")
+    assert surviving.state is IdempotencyState.IN_FLIGHT
+
+
 # ---------------------------------------------------------------------------
 # CachedResponse roundtrip — defends the encode/decode contract end-to-end
 # ---------------------------------------------------------------------------

--- a/tests/test_stores_conformance.py
+++ b/tests/test_stores_conformance.py
@@ -29,6 +29,7 @@ from fastapi_idempotency import (
     CachedResponse,
     Fingerprint,
     IdempotencyKey,
+    IdempotencyRecord,
     IdempotencyState,
     InMemoryStore,
     Store,
@@ -51,6 +52,28 @@ RESPONSE = CachedResponse(
     body=b'{"id": 42, "status": "ok"}',
     media_type="application/json",
 )
+
+
+def _record(
+    key: IdempotencyKey = KEY,
+    fingerprint: Fingerprint = FP,
+    *,
+    ttl: float = 30.0,
+) -> IdempotencyRecord:
+    """Synthesize an IN_FLIGHT record matching what ``acquire`` returns.
+
+    Used by tests that exercise ``complete`` without going through a real
+    ``acquire`` — e.g. error paths where the slot was never created.
+    """
+    now = time.time()
+    return IdempotencyRecord(
+        key=key,
+        fingerprint=fingerprint,
+        state=IdempotencyState.IN_FLIGHT,
+        created_at=now,
+        expires_at=now + ttl,
+        response=None,
+    )
 
 
 @pytest.fixture(
@@ -131,8 +154,8 @@ async def test_acquire_mismatch_after_complete(store: Store) -> None:
     would replay a cached response across users with different
     fingerprints — a real cross-tenant leak. Cheap to test, important.
     """
-    await store.acquire(KEY, FP, ttl=30.0)
-    await store.complete(KEY, RESPONSE, ttl=3600.0)
+    acquired = await store.acquire(KEY, FP, ttl=30.0)
+    await store.complete(acquired.record, RESPONSE, ttl=3600.0)
 
     result = await store.acquire(KEY, Fingerprint("fp-xyz"), ttl=30.0)
 
@@ -140,8 +163,8 @@ async def test_acquire_mismatch_after_complete(store: Store) -> None:
 
 
 async def test_acquire_after_complete_returns_replay(store: Store) -> None:
-    await store.acquire(KEY, FP, ttl=30.0)
-    await store.complete(KEY, RESPONSE, ttl=3600.0)
+    acquired = await store.acquire(KEY, FP, ttl=30.0)
+    await store.complete(acquired.record, RESPONSE, ttl=3600.0)
 
     result = await store.acquire(KEY, FP, ttl=30.0)
 
@@ -173,9 +196,9 @@ async def test_get_returns_record_for_known_key(store: Store) -> None:
 
 
 async def test_complete_transitions_state_with_response(store: Store) -> None:
-    await store.acquire(KEY, FP, ttl=30.0)
+    acquired = await store.acquire(KEY, FP, ttl=30.0)
 
-    await store.complete(KEY, RESPONSE, ttl=3600.0)
+    await store.complete(acquired.record, RESPONSE, ttl=3600.0)
 
     record = await store.get(KEY)
     assert record is not None
@@ -188,7 +211,7 @@ async def test_complete_preserves_identity(store: Store) -> None:
     acquired = await store.acquire(KEY, FP, ttl=30.0)
     original = acquired.record
 
-    await store.complete(KEY, RESPONSE, ttl=3600.0)
+    await store.complete(original, RESPONSE, ttl=3600.0)
 
     record = await store.get(KEY)
     assert record is not None
@@ -199,7 +222,29 @@ async def test_complete_preserves_identity(store: Store) -> None:
 
 async def test_complete_raises_on_unknown_key(store: Store) -> None:
     with pytest.raises(StoreError):
-        await store.complete(KEY, RESPONSE, ttl=3600.0)
+        await store.complete(_record(), RESPONSE, ttl=3600.0)
+
+
+async def test_complete_rejects_fingerprint_mismatch(store: Store) -> None:
+    """Long-handler race: the slot the caller acquired was released and
+    re-acquired by a different request before this ``complete`` fires.
+
+    Both backends must reject — otherwise the late ``complete`` would
+    silently overwrite the new tenant's slot with the original handler's
+    response.
+    """
+    original = (await store.acquire(KEY, FP, ttl=30.0)).record
+    await store.release(KEY)
+    await store.acquire(KEY, Fingerprint("fp-other"), ttl=30.0)
+
+    with pytest.raises(StoreError):
+        await store.complete(original, RESPONSE, ttl=3600.0)
+
+    # The new tenant's slot survived intact — no silent overwrite.
+    surviving = await store.get(KEY)
+    assert surviving is not None
+    assert surviving.fingerprint == Fingerprint("fp-other")
+    assert surviving.state is IdempotencyState.IN_FLIGHT
 
 
 # ---------------------------------------------------------------------------
@@ -234,11 +279,11 @@ async def test_double_release_is_noop(store: Store) -> None:
 
 async def test_complete_after_release_raises(store: Store) -> None:
     """release wipes the slot; subsequent complete has no record to update."""
-    await store.acquire(KEY, FP, ttl=30.0)
+    acquired = await store.acquire(KEY, FP, ttl=30.0)
     await store.release(KEY)
 
     with pytest.raises(StoreError):
-        await store.complete(KEY, RESPONSE, ttl=3600.0)
+        await store.complete(acquired.record, RESPONSE, ttl=3600.0)
 
 
 async def test_acquire_after_release_returns_created(store: Store) -> None:
@@ -316,8 +361,8 @@ async def test_completed_record_expires_with_completed_ttl(store: Store) -> None
     """``complete``'s ``ttl`` argument actually drives expiry — separate
     knob from ``acquire``'s in-flight ttl. Operators rely on this for
     tuning replay-window length without touching in-flight semantics."""
-    await store.acquire(KEY, FP, ttl=30.0)
-    await store.complete(KEY, RESPONSE, ttl=_TTL_S)
+    acquired = await store.acquire(KEY, FP, ttl=30.0)
+    await store.complete(acquired.record, RESPONSE, ttl=_TTL_S)
     await asyncio.sleep(_TTL_WAIT_S)
 
     assert await store.get(KEY) is None
@@ -327,17 +372,17 @@ async def test_completed_record_expires_with_completed_ttl(store: Store) -> None
 async def test_complete_after_ttl_expires_raises(store: Store) -> None:
     """Production race: in-flight TTL elapses before the handler finishes.
 
-    Both backends must raise — Redis via ``_COMPLETE_LUA``'s ``EXISTS``
-    check after PEXPIRE eviction, InMemory via the ``is_expired``
-    guard. Without this conformance test InMemory used to silently
-    overwrite the expired slot with a fresh COMPLETED record, hiding
-    the ``in_flight_ttl`` tuning bug operators are supposed to see.
+    Both backends must raise — Redis via the Lua's missing-key check
+    after PEXPIRE eviction, InMemory via the ``is_expired`` guard.
+    Without this conformance test InMemory used to silently overwrite
+    the expired slot with a fresh COMPLETED record, hiding the
+    ``in_flight_ttl`` tuning bug operators are supposed to see.
     """
-    await store.acquire(KEY, FP, ttl=_TTL_S)
+    acquired = await store.acquire(KEY, FP, ttl=_TTL_S)
     await asyncio.sleep(_TTL_WAIT_S)
 
     with pytest.raises(StoreError):
-        await store.complete(KEY, RESPONSE, ttl=3600.0)
+        await store.complete(acquired.record, RESPONSE, ttl=3600.0)
 
 
 # ---------------------------------------------------------------------------
@@ -352,8 +397,8 @@ async def test_response_roundtrip_preserves_all_fields(store: Store) -> None:
     override on a future CachedResponse subclass — equality could pass
     while a field silently regresses.
     """
-    await store.acquire(KEY, FP, ttl=30.0)
-    await store.complete(KEY, RESPONSE, ttl=3600.0)
+    acquired = await store.acquire(KEY, FP, ttl=30.0)
+    await store.complete(acquired.record, RESPONSE, ttl=3600.0)
 
     result = await store.acquire(KEY, FP, ttl=30.0)
 

--- a/tests/test_stores_redis.py
+++ b/tests/test_stores_redis.py
@@ -26,7 +26,6 @@ from fastapi_idempotency import (
     StoreError,
 )
 from fastapi_idempotency.stores import redis as redis_module
-from fastapi_idempotency.stores._serde import encode_record
 from fastapi_idempotency.stores.redis import (
     _ACQUIRE_LUA,
     RedisStore,
@@ -157,17 +156,19 @@ FP = Fingerprint("f")
 RESPONSE = CachedResponse(status_code=200, headers=(), body=b"")
 
 
-def _existing_record_bytes() -> bytes:
-    """An IN_FLIGHT record with future ``expires_at`` for complete-path setup."""
-    return encode_record(
-        IdempotencyRecord(
-            key=KEY,
-            fingerprint=FP,
-            state=IdempotencyState.IN_FLIGHT,
-            created_at=time.time(),
-            expires_at=time.time() + 30.0,
-            response=None,
-        ),
+def _in_flight_record() -> IdempotencyRecord:
+    """The in-flight record a caller would pass to ``complete``.
+
+    Same shape as the ``acquire`` result for ``KEY`` / ``FP``.
+    """
+    now = time.time()
+    return IdempotencyRecord(
+        key=KEY,
+        fingerprint=FP,
+        state=IdempotencyState.IN_FLIGHT,
+        created_at=now,
+        expires_at=now + 30.0,
+        response=None,
     )
 
 
@@ -188,26 +189,17 @@ async def test_get_wraps_redis_error_with_op_name() -> None:
         await store.get(KEY)
 
 
-async def test_complete_wraps_hget_redis_error_with_op_name() -> None:
-    client = _stub_client(hget_raises=RedisError("boom"))
-    store = RedisStore(client)
-
-    with pytest.raises(StoreError, match="Redis complete failed"):
-        await store.complete(KEY, RESPONSE, ttl=3600.0)
-
-
-async def test_complete_wraps_script_redis_error_with_op_name() -> None:
-    """The complete path has TWO redis-py call sites (HGET then EVAL).
-    Each must wrap independently — covers the second except path."""
+async def test_complete_wraps_redis_error_with_op_name() -> None:
+    """``complete`` is a single Lua EVAL — its only Redis call site must
+    wrap exceptions as ``StoreError`` with the op name."""
     complete_script = AsyncMock(side_effect=RedisError("boom"))
     client = _stub_client(
         register_script_returns=(AsyncMock(), complete_script),
-        hget_returns=_existing_record_bytes(),
     )
     store = RedisStore(client)
 
     with pytest.raises(StoreError, match="Redis complete failed"):
-        await store.complete(KEY, RESPONSE, ttl=3600.0)
+        await store.complete(_in_flight_record(), RESPONSE, ttl=3600.0)
 
 
 async def test_release_wraps_redis_error_with_op_name() -> None:

--- a/tests/test_stores_redis.py
+++ b/tests/test_stores_redis.py
@@ -121,16 +121,15 @@ def test_wrap_redis_error_returns_store_error_with_op_in_message() -> None:
 def _stub_client(
     *,
     register_script_returns: tuple[Any, Any] | None = None,
-    hget_returns: Any = None,
     hget_raises: BaseException | None = None,
     delete_raises: BaseException | None = None,
 ) -> MagicMock:
     """Build a minimal ``redis.asyncio.Redis``-shaped stub.
 
-    ``register_script_returns`` is a 2-tuple corresponding to the two
-    ``register_script`` calls in ``RedisStore.__init__`` (acquire then
-    complete). ``hget_returns``/``hget_raises`` configure the shared
-    ``hget`` mock; ``delete_raises`` configures ``delete``.
+    ``register_script_returns`` is a 2-tuple matching the two
+    ``register_script`` calls in ``RedisStore.__init__`` (acquire
+    then complete). ``hget_raises`` injects a fault into ``get``;
+    ``delete_raises`` injects one into ``release``.
     """
     client = MagicMock()
     encoder = MagicMock()
@@ -143,7 +142,7 @@ def _stub_client(
     if hget_raises is not None:
         client.hget = AsyncMock(side_effect=hget_raises)
     else:
-        client.hget = AsyncMock(return_value=hget_returns)
+        client.hget = AsyncMock(return_value=None)
     if delete_raises is not None:
         client.delete = AsyncMock(side_effect=delete_raises)
     else:

--- a/tests/test_stores_redis.py
+++ b/tests/test_stores_redis.py
@@ -202,6 +202,27 @@ async def test_complete_wraps_redis_error_with_op_name() -> None:
         await store.complete(_in_flight_record(), RESPONSE, ttl=3600.0)
 
 
+async def test_complete_is_single_round_trip() -> None:
+    """``complete`` must be one redis call — the Lua EVAL with caller's fp.
+
+    The v0.2.0 implementation issued an extra HGET to read the stored
+    fingerprint before the EVAL (2 RTTs, with a TOCTOU window). v0.3.0
+    drops the HGET — the caller's record already carries the fingerprint
+    so the Lua can fp-check directly. Regression-guards a future refactor
+    that re-adds a Python-side probe and silently doubles latency.
+    """
+    complete_script = AsyncMock(return_value=b"ok")
+    client = _stub_client(
+        register_script_returns=(AsyncMock(), complete_script),
+    )
+    store = RedisStore(client)
+
+    await store.complete(_in_flight_record(), RESPONSE, ttl=3600.0)
+
+    assert complete_script.await_count == 1
+    assert client.hget.await_count == 0
+
+
 async def test_release_wraps_redis_error_with_op_name() -> None:
     client = _stub_client(delete_raises=RedisError("boom"))
     store = RedisStore(client)

--- a/tests/test_stores_redis_integration.py
+++ b/tests/test_stores_redis_integration.py
@@ -79,50 +79,11 @@ async def test_get_filters_python_side_expired_record(
 
 
 @pytest.mark.redis
-async def test_complete_raises_on_python_side_expired_record(
-    redis_client: redis.asyncio.Redis,
-) -> None:
-    """``RedisStore.complete`` raises ``StoreError`` when the existing
-    record is expired by Python clock, even if PEXPIRE hasn't fired.
-
-    Symmetric with ``test_get_filters_python_side_expired_record`` —
-    catches the sub-millisecond race that would otherwise let
-    ``complete`` silently overwrite an expired-but-still-in-Redis slot.
-    """
-    store = RedisStore(redis_client)
-    key = IdempotencyKey("python-side-expired-complete")
-    full_key = store._key(key)
-
-    expired_record = IdempotencyRecord(
-        key=key,
-        fingerprint=Fingerprint("fp"),
-        state=IdempotencyState.IN_FLIGHT,
-        created_at=time.time() - 100,
-        expires_at=time.time() - 1.0,  # already elapsed by Python clock
-        response=None,
-    )
-    await redis_client.hset(
-        full_key,
-        mapping={
-            b"fp": b"fp",
-            b"state": b"in_flight",
-            b"data": encode_record(expired_record),
-        },
-    )
-    await redis_client.pexpire(full_key, 60_000)  # PEXPIRE not yet fired
-
-    response = CachedResponse(status_code=200, headers=(), body=b"")
-    with pytest.raises(StoreError):
-        await store.complete(key, response, ttl=3600.0)
-
-
-@pytest.mark.redis
 async def test_complete_lua_rejects_fp_mismatch(
     redis_client: redis.asyncio.Redis,
 ) -> None:
     """The ``_COMPLETE_LUA`` script must refuse to overwrite a slot whose
-    stored fp differs from the expected fp the caller observed — the
-    eviction + re-acquire race that Python's HGET-then-EVAL window opens.
+    stored fp differs from the expected fp the caller passed in.
 
     Drives the Lua directly with a stale ``expected_fp`` to simulate
     worker A's view of the slot before worker B's re-acquire swapped it.
@@ -165,11 +126,10 @@ async def test_complete_lua_rejects_fp_mismatch(
 @pytest.mark.redis
 async def test_complete_full_path_rejects_eviction_and_reacquire(
     redis_client: redis.asyncio.Redis,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """End-to-end through ``RedisStore.complete``: an eviction + re-acquire
-    that lands between the Python-side HGET and the Lua EVAL raises
-    ``StoreError`` instead of silently overwriting the fresh slot.
+    that swaps the slot's fp before complete fires raises ``StoreError``
+    instead of silently overwriting the fresh slot.
 
     Guards the Python glue (correct fp passed as ``expected_fp``) on top of
     the Lua-only ``test_complete_lua_rejects_fp_mismatch``. A regression
@@ -188,38 +148,24 @@ async def test_complete_full_path_rejects_eviction_and_reacquire(
         expires_at=time.time() + 30.0,
         response=None,
     )
+
+    # Simulate the race: slot was acquired by request A (fp_a), then
+    # evicted and re-acquired by request B (fp_b) before A's complete fires.
+    reacquired = replace(original, fingerprint=Fingerprint("fp_b"))
     await redis_client.hset(
         full_key,
         mapping={
-            b"fp": b"fp_a",
+            b"fp": b"fp_b",
             b"state": b"in_flight",
-            b"data": encode_record(original),
+            b"data": encode_record(reacquired),
         },
     )
     await redis_client.pexpire(full_key, 60_000)
 
-    real_hget = store.client.hget
-    swap_done = False
-
-    async def hget_then_swap(name: str, field: str) -> bytes | None:
-        nonlocal swap_done
-        result: bytes | None = await real_hget(name, field)
-        if not swap_done:
-            swap_done = True
-            reacquired = replace(original, fingerprint=Fingerprint("fp_b"))
-            await redis_client.hset(
-                full_key,
-                mapping={b"fp": b"fp_b", b"data": encode_record(reacquired)},
-            )
-        return result
-
-    monkeypatch.setattr(store.client, "hget", hget_then_swap)
-
     response = CachedResponse(status_code=200, headers=(), body=b"")
     with pytest.raises(StoreError):
-        await store.complete(key, response, ttl=3600.0)
+        await store.complete(original, response, ttl=3600.0)
 
-    monkeypatch.undo()
     # fp_b's IN_FLIGHT slot survived intact — no silent overwrite.
     assert await redis_client.hget(full_key, "fp") == b"fp_b"
     assert await redis_client.hget(full_key, "state") == b"in_flight"


### PR DESCRIPTION
Closes #44

## Summary

Closes the long-handler race on `Store.complete`. The protocol now takes the in-flight `IdempotencyRecord` (the one `acquire` returned) and both backends fp-check the caller's record against the stored slot inside their atomic section before any write — a handler outliving `in_flight_ttl` can no longer silently overwrite a slot re-acquired by a different request.

Four commits:

- **`feat(store)!: pass acquired record through Store.complete`** — Protocol change: `Store.complete(record, response, ttl)` replaces `Store.complete(key, response, ttl)`. `InMemoryStore.complete` adds an in-lock `existing.fingerprint != record.fingerprint` guard. `RedisStore.complete` becomes a single Lua `EVAL` (1-RTT instead of 2) — the v0.2.0 Python-side `HGET` probe and its Python-clock `is_expired` defense-in-depth are gone; the in-Lua fp check is the only guard. Middleware threads `result.record` from `acquire` through `_run_and_cache` to `store.complete`. Existing tests adapted; one redis integration test removed (`test_complete_raises_on_python_side_expired_record` depended on the now-gone Python-side HGET). **BREAKING** (pre-1.0) for third-party `Store` implementations.
- **`test(store): cover long-handler race via TTL eviction + redis 1-RTT`** — New slow conformance test `test_complete_rejects_fp_mismatch_after_ttl_reacquire` drives the production scenario end-to-end via real TTL eviction + `asyncio.sleep`, complementing the fast `test_complete_rejects_fingerprint_mismatch` (release-based). New redis mock test `test_complete_is_single_round_trip` regression-guards the 1-RTT property (`complete_script.await_count == 1`, `client.hget.await_count == 0`).
- **`docs: close long-handler race caveat for v0.3.0`** — CHANGELOG `[Unreleased]` populated with BREAKING (protocol) + Fixed (race closure + 1-RTT). README `Configuration caveats` `in_flight_ttl` bullet rewritten — no longer claims the fix lands in v0.3.0, it lands here. New `docs/DESIGN.md` section "Long-handler race closure" (Status: v0.3.0) with per-backend changes, the Python-clock-guard trade-off, residuals.
- **`refactor(store): converge complete on caller's record; tighten docs and contract`** — `InMemoryStore.complete` now writes the caller's `record` (via `replace(record, ...)`) to match `RedisStore`, so under same-fp ABA both backends preserve the caller's `created_at` (pinned by new conformance test `test_complete_preserves_callers_created_at_under_same_fp_aba`). `Store.complete` docstring tightened to opaque-token + backend-agnostic spec. DESIGN.md gains a "Conformance requirements" subsection (three MUSTs: presence, fp-equality, caller's `created_at`) with a behavioral "atomic section" definition for hypothetical third-party backends. CHANGELOG/README collapsed release-residual prose to single-clause pointers (DESIGN.md canonical). Dead `hget_returns` param dropped from `_stub_client`; `_record(...)` test helper made keyword-only.

Out of scope, deferred:

- **`Store.release(key)` arm of the same race.** The fp guard sits on `complete`; `release` still wipes by key alone. The middleware's four `release(key)` call paths (handler raises, 5xx, no `http.response.start`, streamed pass-through) can still wipe a slot re-acquired by another request. No cross-tenant *response* leak — only availability failure (the new tenant's `complete` then sees an unknown key and serves with `Idempotency-Stored: false`). Documented in `docs/DESIGN.md` "Long-handler race closure" → "What is not closed". Symmetric closure (`release(record)` with fp check) needs its own protocol change; tracked separately.
- **Same-fp ABA under `secret=None`.** Eviction + re-acquire with an identical body is benign under HMAC mode (both completions are valid retries) but forgeable under `secret=None` if the attacker can guess the body. Documented as another reason `secret=None` is for tests / one-off migration only.

## Test plan

- [x] `uv run pytest -m "not redis and not slow"` — 166 passed locally
- [x] `uv run mypy src/ tests/` clean
- [x] CI matrix expected green across 3.10–3.13 (Redis service container)
- [x] Conformance suite pins all three new MUSTs (fp mismatch, unknown key, caller's `created_at` under same-fp ABA)
- [x] Redis integration tests cover the Lua-isolated fp check and the full `complete`-path eviction+reacquire scenario