### PR TITLE
feat: scope_factory for per-tenant / per-route key scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Security
+### Added
 
-- Raised dependency floors to pull in security fixes: `starlette>=1.3.1`
-  (CVE-2026-48817, CVE-2026-48818, PYSEC-2026-248, PYSEC-2026-249) and
-  `msgpack>=1.2.1` (GHSA-6v7p-g79w-8964). The lockfile now resolves the
-  patched releases; `pip-audit` is clean.
+- `scope_factory` parameter on `IdempotencyMiddleware`: an optional
+  `Callable[[Request], bytes]` that isolates the idempotency key per
+  tenant / user / route, so two tenants sharing a key value no longer
+  collide on one record. The scope is prefixed onto the key (never
+  folded into the body fingerprint); a factory that raises yields `500`
+  and one returning empty bytes yields `400`, both before the handler
+  runs. Default `None` preserves the v0.2.0 single-tenant behavior.
 
 ### Changed
 
@@ -35,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   closure" for scope and residuals.)
 - `RedisStore.complete` is now a single round-trip (Lua `EVAL`
   only); the v0.2.0 Python-side `HGET` probe is gone.
+
+### Security
+
+- Raised dependency floors to pull in security fixes: `starlette>=1.3.1`
+  (CVE-2026-48817, CVE-2026-48818, PYSEC-2026-248, PYSEC-2026-249) and
+  `msgpack>=1.2.1` (GHSA-6v7p-g79w-8964). The lockfile now resolves the
+  patched releases; `pip-audit` is clean.
 
 ## [0.2.0] - 2026-05-23
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,43 @@ bytes and `decode_responses=True` would silently corrupt msgpack.
 TTL eviction uses Redis `PEXPIRE`; record fields are advisory metadata
 (query Redis `PTTL` for the eviction authority).
 
+### Multi-tenant key scoping
+
+By default the `Idempotency-Key` is the whole key: two tenants that
+happen to pick the same key value collide on one record. Pass a
+`scope_factory` to isolate them — a `Callable[[Request], bytes]` whose
+returned bytes are prefixed onto the key before the store sees it:
+
+```python
+import os
+
+from fastapi import FastAPI
+
+from fastapi_idempotency import IdempotencyMiddleware, InMemoryStore
+
+app = FastAPI()
+app.add_middleware(
+    IdempotencyMiddleware,
+    store=InMemoryStore(),
+    secret=os.environ["IDEMP_SECRET"].encode(),
+    scope_factory=lambda request: request.headers["X-Tenant-Id"].encode(),
+)
+```
+
+Now the same key from `tenant-a` and `tenant-b` maps to two independent
+records; scope isolation is orthogonal to the body fingerprint, so a
+body change within one tenant still surfaces as a `422` mismatch. The
+factory receives the full Starlette `Request`, so it can also scope by
+authenticated identity (`request.user`) or by an attribute an upstream
+middleware set on `request.state`.
+
+The factory runs before the body is buffered and before any store slot
+is created. If it **raises** (e.g. a required header is missing) the
+request gets `500` without invoking the handler; if it returns **empty
+bytes** it gets `400`. See [`docs/DESIGN.md`](docs/DESIGN.md) ("Key
+scoping") for why an empty scope is rejected, the determinism contract,
+and the collision-safe key-combining scheme.
+
 ## How it works
 
 The middleware watches non-safe HTTP methods (POST/PATCH/PUT/DELETE) for
@@ -218,11 +255,13 @@ The middleware deduplicates concurrent and retried requests on non-safe
 methods. It is **not** a substitute for authentication or authorization.
 Assumptions:
 
-- **No per-tenant key scoping.** Fingerprints cover
-  `(method, path, query, body)` only. Two users sending the same key
-  with the same request see the same cached response — the first
-  tenant's response leaks to the second. Multiplex tenants upstream
-  (per-tenant store, namespaced keys, custom `Store`).
+- **Single-tenant by default; opt into scoping.** Fingerprints cover
+  `(method, path, query, body)` only. Without a `scope_factory` two
+  users sending the same key with the same request see the same cached
+  response — the first tenant's response leaks to the second. Pass a
+  `scope_factory` (see "Multi-tenant key scoping") to isolate tenants
+  inside one store, or multiplex upstream (per-tenant store, namespaced
+  keys, custom `Store`).
 - **HMAC secret required for shared stores.** With `secret=None` the
   fingerprint is plain SHA-256, so an attacker who controls a client
   can probe via wire outcomes (`409` in-flight, `422` mismatch,

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -459,11 +459,61 @@ silently).
 
 ## Key scoping (`scope_factory`)
 
-**Status: planned for v0.3.0.** Not yet implemented.
+**Status: v0.3.0.**
 
-The current key-extraction reads `Idempotency-Key` from the request
-headers. Multi-tenant deployments often want to scope the key by
-something else — tenant ID, authenticated user, route prefix — so
-two tenants sharing the wire-level header don't collide. `scope_factory`
-will be a callable `(scope) -> bytes` injected into the middleware that
-prefixes the raw header value before the store sees it.
+Key extraction reads `Idempotency-Key` from the request headers.
+Multi-tenant deployments often want to scope the key by something else —
+tenant ID, authenticated user, route prefix — so two tenants sharing the
+wire-level header don't collide. `scope_factory` is an optional
+`Callable[[Request], bytes]` injected into the middleware; it receives a
+Starlette `Request` (full access to `request.state`, `request.user`, and
+attributes set by upstream middleware) and returns the bytes that isolate
+the caller's store namespace.
+
+### Combining scope with the key
+
+The returned bytes are hex-encoded and joined to the raw `Idempotency-Key`
+with a `:`:
+
+```python
+store_key = f"{scope_bytes.hex()}:{raw_key}"
+```
+
+Hex output is drawn from `[0-9a-f]` and never contains `:`, so the split
+point is unambiguous and distinct `(scope, key)` pairs can never collide
+onto one store key (the same length-prefixing concern the fingerprint
+solves, met here by a delimiter the prefix alphabet excludes). With
+`scope_factory=None` (the default) the raw key is used unchanged — the
+v0.2.0 single-tenant behavior is preserved byte-for-byte.
+
+Scope is woven into the **key**, not the **fingerprint**: the fingerprint
+already covers `(method, path, query, body)`; scope is an orthogonal axis
+of isolation. Two requests differing only in scope are independent slots,
+while a body change within one scope still surfaces as a `MISMATCH`.
+
+### Resolution timing and failure modes
+
+The factory runs once per intercepted request, before body buffering and
+before `Store.acquire` — a rejected request costs neither a buffered body
+nor a store slot, and the handler is never invoked. Failure handling:
+
+- **Factory raises** → **500**. A raise is a bug in caller code (e.g. a
+  missing header it assumed was present), not a client protocol error. The
+  message is fixed (`could not resolve idempotency scope`) and logged at
+  WARNING without `exc_info` — the exception text may carry the raw key or
+  a tenant identifier (see "Logging — keys hashed").
+- **Factory returns empty `b""`** → **400**. An empty scope would silently
+  collapse every tenant onto the shared namespace, so it is rejected as a
+  fail-fast client precondition rather than honored.
+
+### Determinism contract
+
+Like the fingerprint, `scope_factory` must be **deterministic with respect
+to the request**: the same request must always yield the same scope bytes.
+The scope prefix is not persisted anywhere — it is recomputed on every
+request from the request itself. A factory that depends on per-process or
+per-restart state (a `uuid4()` fixed at startup, `os.getpid()`, a random
+seed) would compute a different prefix after a restart or on another
+worker, so a completed record would no longer be found and replays would
+break. Derive scope only from stable request data (headers, auth identity,
+route), never from process-local state.

--- a/src/fastapi_idempotency/__init__.py
+++ b/src/fastapi_idempotency/__init__.py
@@ -4,7 +4,9 @@ Public API is the names listed in ``__all__``. Store-implementation
 types (``AcquireOutcome``, ``AcquireResult``, ``IdempotencyRecord``,
 ``IdempotencyState``, ``CachedResponse``, ``IdempotencyKey``,
 ``Fingerprint``) are importable for users writing custom ``Store``
-implementations but kept out of ``__all__`` as advanced surface.
+implementations but kept out of ``__all__`` as advanced surface. The
+``ScopeFactory`` alias is likewise importable for annotating a custom
+``scope_factory`` callable.
 
 ``RedisStore`` is loaded lazily via :pep:`562` ``__getattr__`` so
 ``import fastapi_idempotency`` works without the ``[redis]`` extra.
@@ -19,7 +21,10 @@ from .errors import (
     RequestTooLargeError,
     StoreError,
 )
-from .middleware import IdempotencyMiddleware
+from .middleware import (
+    IdempotencyMiddleware,
+    ScopeFactory as ScopeFactory,
+)
 from .store import Store
 from .stores.memory import InMemoryStore
 from .types import (

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import hashlib
 import hmac
 import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING, ClassVar
+
+from starlette.requests import Request
 
 from .body_buffer import buffer_request_body
 from .errors import RequestTooLargeError, StoreError
@@ -25,6 +28,14 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+# Returns the bytes prefixed onto the raw Idempotency-Key to isolate the
+# store namespace (per tenant / user / route). Full ``Request`` access so
+# the factory can read auth context (``request.user``) or attributes set
+# by upstream middleware (``request.state``). See ``docs/DESIGN.md``
+# ("Key scoping (scope_factory)").
+ScopeFactory = Callable[[Request], bytes]
 
 
 class _Missing:
@@ -125,6 +136,7 @@ class IdempotencyMiddleware:
         completed_ttl: float = 86_400.0,
         max_body_bytes: int | None = None,
         require_key: bool = False,
+        scope_factory: ScopeFactory | None = None,
     ) -> None:
         if isinstance(secret, _Missing):
             msg = (
@@ -141,6 +153,7 @@ class IdempotencyMiddleware:
         self.completed_ttl = completed_ttl
         self.max_body_bytes = max_body_bytes
         self.require_key = require_key
+        self.scope_factory = scope_factory
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
@@ -176,20 +189,68 @@ class IdempotencyMiddleware:
             await self.app(scope, receive, send)
             return
 
-        await self._handle_intercepted(
-            scope,
-            receive,
-            send,
-            IdempotencyKey(key_value),
-        )
+        await self._handle_intercepted(scope, receive, send, key_value)
+
+    async def _resolve_store_key(
+        self,
+        scope: Scope,
+        key_value: str,
+        send: Send,
+    ) -> IdempotencyKey | None:
+        """Apply ``scope_factory`` to the raw key, or send an error and None.
+
+        The factory bytes are hex-encoded and joined to the raw key with
+        ``:`` — hex carries no ``:``, so the split point is unambiguous and
+        distinct ``(scope, key)`` pairs never collide. With no factory the
+        raw key is used unchanged (the v0.2.0 single-tenant behavior).
+        """
+        if self.scope_factory is None:
+            return IdempotencyKey(key_value)
+
+        try:
+            scope_bytes = self.scope_factory(Request(scope))
+        except Exception as exc:
+            # Factory is caller code; a raise is a bug there, not a client
+            # error — surface 500. No exc_info: the message may carry the
+            # raw key or tenant identifiers (see DESIGN.md "Logging").
+            logger.warning(
+                "scope_factory raised; responding 500",
+                extra={
+                    **_log_context(IdempotencyKey(key_value), self._secret),
+                    "exc_type": type(exc).__name__,
+                },
+            )
+            await self._send_plain_response(
+                send,
+                status=500,
+                message="could not resolve idempotency scope",
+            )
+            return None
+
+        if not scope_bytes:
+            # Empty scope would silently collapse every tenant onto the
+            # shared namespace — fail fast as a client-side precondition.
+            await self._send_plain_response(
+                send,
+                status=400,
+                message="idempotency scope is empty",
+            )
+            return None
+
+        return IdempotencyKey(f"{scope_bytes.hex()}:{key_value}")
 
     async def _handle_intercepted(
         self,
         scope: Scope,
         receive: Receive,
         send: Send,
-        key: IdempotencyKey,
+        key_value: str,
     ) -> None:
+        # Resolve scope before buffering: a failing factory should reject
+        # the request without paying for body buffering or a store slot.
+        key = await self._resolve_store_key(scope, key_value, send)
+        if key is None:
+            return
         try:
             body, replay = await buffer_request_body(
                 receive,

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1002,3 +1002,159 @@ async def test_concurrent_request_with_same_key_returns_409() -> None:
 
     assert r1.status_code == 200
     assert r2.status_code == 409
+
+
+def _tenant_scope_middleware(app: Any, store: InMemoryStore) -> IdempotencyMiddleware:
+    """Middleware scoping the key by the ``X-Tenant-Id`` request header."""
+    return IdempotencyMiddleware(
+        app,
+        store,
+        secret=None,
+        scope_factory=lambda req: req.headers["x-tenant-id"].encode(),
+    )
+
+
+async def test_scope_factory_different_scope_does_not_replay() -> None:
+    """Same key + same body but different scope → two independent CREATEDs.
+
+    Without scoping these would collide on one record and the second would
+    REPLAY; the factory must keep the tenants isolated.
+    """
+    invocations = 0
+
+    async def counting_app(scope: Scope, receive: Receive, send: Send) -> None:
+        nonlocal invocations
+        invocations += 1
+        await echo_app(scope, receive, send)
+
+    middleware = _tenant_scope_middleware(counting_app, InMemoryStore())
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        first = await client.post(
+            "/",
+            headers={"Idempotency-Key": "abc", "X-Tenant-Id": "tenant-a"},
+            content=b"hi",
+        )
+        second = await client.post(
+            "/",
+            headers={"Idempotency-Key": "abc", "X-Tenant-Id": "tenant-b"},
+            content=b"hi",
+        )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert "idempotent-replayed" not in second.headers
+    assert invocations == 2
+
+
+async def test_scope_factory_same_scope_replays() -> None:
+    """Same key + same body + same scope preserves CREATED → REPLAY."""
+    middleware = _tenant_scope_middleware(echo_app, InMemoryStore())
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        headers = {"Idempotency-Key": "abc", "X-Tenant-Id": "tenant-a"}
+        first = await client.post("/", headers=headers, content=b"hi")
+        replay = await client.post("/", headers=headers, content=b"hi")
+
+    assert first.status_code == 200
+    assert replay.headers.get("idempotent-replayed") == "true"
+
+
+async def test_scope_factory_orthogonal_to_fingerprint() -> None:
+    """Scope isolates the key; the fingerprint still guards body reuse.
+
+    Same key + same scope + different body must still be a 422 MISMATCH,
+    while a different scope makes the otherwise-mismatching pair two
+    independent CREATEDs — proving scope and fingerprint are separate axes.
+    """
+    middleware = _tenant_scope_middleware(echo_app, InMemoryStore())
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        created = await client.post(
+            "/",
+            headers={"Idempotency-Key": "abc", "X-Tenant-Id": "tenant-a"},
+            content=b"first-body",
+        )
+        mismatch = await client.post(
+            "/",
+            headers={"Idempotency-Key": "abc", "X-Tenant-Id": "tenant-a"},
+            content=b"second-body",
+        )
+        other_tenant = await client.post(
+            "/",
+            headers={"Idempotency-Key": "abc", "X-Tenant-Id": "tenant-b"},
+            content=b"second-body",
+        )
+
+    assert created.status_code == 200
+    assert mismatch.status_code == 422
+    assert other_tenant.status_code == 200
+
+
+async def test_scope_factory_raising_returns_500_without_handler() -> None:
+    """A factory that raises (e.g. missing tenant header) → 500, no handler,
+    no store slot."""
+    invocations = 0
+
+    async def counting_app(scope: Scope, receive: Receive, send: Send) -> None:
+        nonlocal invocations
+        invocations += 1
+        await echo_app(scope, receive, send)
+
+    store = InMemoryStore()
+    middleware = _tenant_scope_middleware(counting_app, store)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/",
+            headers={"Idempotency-Key": "abc"},  # no X-Tenant-Id → KeyError
+            content=b"hi",
+        )
+
+    assert response.status_code == 500
+    assert response.text == "could not resolve idempotency scope"
+    assert invocations == 0
+
+
+async def test_scope_factory_empty_bytes_returns_400_without_handler() -> None:
+    """A factory returning empty bytes is a fail-fast 400, never a silent
+    collapse onto the shared namespace."""
+    invocations = 0
+
+    async def counting_app(scope: Scope, receive: Receive, send: Send) -> None:
+        nonlocal invocations
+        invocations += 1
+        await echo_app(scope, receive, send)
+
+    middleware = IdempotencyMiddleware(
+        counting_app,
+        InMemoryStore(),
+        secret=None,
+        scope_factory=lambda _req: b"",
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/",
+            headers={"Idempotency-Key": "abc"},
+            content=b"hi",
+        )
+
+    assert response.status_code == 400
+    assert response.text == "idempotency scope is empty"
+    assert invocations == 0

--- a/tests/test_stores_conformance.py
+++ b/tests/test_stores_conformance.py
@@ -22,6 +22,7 @@ import time
 from collections import Counter
 from typing import TYPE_CHECKING
 
+import httpx
 import pytest
 
 from fastapi_idempotency import (
@@ -29,6 +30,7 @@ from fastapi_idempotency import (
     CachedResponse,
     Fingerprint,
     IdempotencyKey,
+    IdempotencyMiddleware,
     IdempotencyRecord,
     IdempotencyState,
     InMemoryStore,
@@ -39,6 +41,8 @@ from fastapi_idempotency.stores.redis import RedisStore
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from starlette.types import Receive, Scope, Send
 
 
 KEY = IdempotencyKey("order-conformance")
@@ -459,3 +463,76 @@ async def test_response_roundtrip_preserves_all_fields(store: Store) -> None:
     assert result.record.response.headers == RESPONSE.headers
     assert result.record.response.body == RESPONSE.body
     assert result.record.response.media_type == "application/json"
+
+
+# ---------------------------------------------------------------------------
+# scope_factory — scoping is store-agnostic, so it must behave identically
+# on every backend (scoped keys round-trip through the real Redis key space)
+# ---------------------------------------------------------------------------
+
+
+async def _echo_app(scope: Scope, receive: Receive, send: Send) -> None:
+    """Minimal ASGI app echoing the request body, or 'ok' if empty."""
+    chunks: list[bytes] = []
+    while True:
+        message = await receive()
+        if message["type"] != "http.request":
+            break
+        chunks.append(message.get("body", b""))
+        if not message.get("more_body", False):
+            break
+    body = b"".join(chunks) or b"ok"
+    await send(
+        {"type": "http.response.start", "status": 200, "headers": []},
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+def _scoped_client(store: Store) -> httpx.AsyncClient:
+    """ASGI client whose middleware scopes the key by ``X-Tenant-Id``."""
+    middleware = IdempotencyMiddleware(
+        _echo_app,
+        store,
+        secret=None,
+        scope_factory=lambda req: req.headers["x-tenant-id"].encode(),
+    )
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=middleware),
+        base_url="http://testserver",
+    )
+
+
+async def test_scope_factory_different_scope_isolates_across_backends(store: Store) -> None:
+    """Same key + same body, different scope → two independent CREATEDs.
+
+    Runs against every backend: the scoped keys must not collide once
+    they round-trip through the real store key space.
+    """
+    async with _scoped_client(store) as client:
+        first = await client.post(
+            "/",
+            headers={"Idempotency-Key": "abc", "X-Tenant-Id": "tenant-a"},
+            content=b"hi",
+        )
+        second = await client.post(
+            "/",
+            headers={"Idempotency-Key": "abc", "X-Tenant-Id": "tenant-b"},
+            content=b"hi",
+        )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert "idempotent-replayed" not in second.headers
+    # Fresh handler output on the second tenant — not a replayed body.
+    assert second.text == "hi"
+
+
+async def test_scope_factory_same_scope_replays_across_backends(store: Store) -> None:
+    """Same key + same body + same scope → CREATED then REPLAY, every backend."""
+    async with _scoped_client(store) as client:
+        headers = {"Idempotency-Key": "abc", "X-Tenant-Id": "tenant-a"}
+        first = await client.post("/", headers=headers, content=b"hi")
+        replay = await client.post("/", headers=headers, content=b"hi")
+
+    assert first.status_code == 200
+    assert replay.headers.get("idempotent-replayed") == "true"


### PR DESCRIPTION
Closes #45. Adds an optional `scope_factory` to `IdempotencyMiddleware` for
per-tenant / per-user / per-route key isolation.

Design, usage, and rationale live in-repo — see rather than restate:
- `docs/DESIGN.md` § "Key scoping" — key-combining scheme, failure modes, determinism contract
- README § "Multi-tenant key scoping" — end-to-end example
- CHANGELOG `[Unreleased] → Added`

## Review notes

- 3 atomic commits: middleware feature → cross-store conformance test → docs.
- Scoping is confined to the store key; the body fingerprint is untouched, and
  `scope_factory=None` (default) is a byte-for-byte no-op.
- Tests cover scope isolation, replay, scope/fingerprint orthogonality, and both
  failure modes (raise → 500, empty → 400) — driven through the middleware
  against both `InMemoryStore` and `RedisStore`.
