### PR TITLE
hardening: production-safe defaults (max_body_bytes=1MiB, in_flight_ttl=60s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING** (pre-1.0): production-safe middleware defaults.
+  `max_body_bytes` now defaults to `1_048_576` (1 MiB) instead of `None`
+  (unbounded), so request bodies over 1 MiB are no longer buffered or
+  deduplicated after upgrade — pass `max_body_bytes=None` to restore
+  v0.2.0 behavior.
+  `in_flight_ttl` now defaults to `60.0` instead of `30.0`. See the
+  README "Upgrading from v0.2.0" note.
 - **BREAKING** (pre-1.0): `Store.complete` signature is now
   `complete(record, response, ttl)` where `record` is the in-flight
   `IdempotencyRecord` returned by `acquire`. Third-party `Store`

--- a/README.md
+++ b/README.md
@@ -281,6 +281,36 @@ Assumptions:
 Deeper rationale and per-decision threat analysis in
 [`docs/DESIGN.md`](docs/DESIGN.md).
 
+## Configuration
+
+`IdempotencyMiddleware` constructor parameters and their defaults:
+
+| Parameter | Default | Purpose |
+| --- | --- | --- |
+| `secret` | *required* | HMAC-SHA256 key for fingerprints; pass `secret=None` for the explicit insecure opt-out |
+| `in_flight_ttl` | `60.0` | seconds a slot stays `IN_FLIGHT` before the store reclaims it |
+| `completed_ttl` | `86_400.0` | seconds a completed response stays replayable (24h) |
+| `max_body_bytes` | `1_048_576` | max buffered request body (1 MiB); `None` = unbounded |
+| `require_key` | `False` | reject non-safe requests missing the header with `400` |
+| `header_name` | `"Idempotency-Key"` | header carrying the key |
+| `scope_factory` | `None` | per-tenant / per-route key scoping (see "Multi-tenant key scoping") |
+
+### Upgrading from v0.2.0
+
+The `max_body_bytes` default changed from `None` (unbounded) to `1_048_576`
+(1 MiB), so request bodies over 1 MiB are no longer buffered or deduplicated:
+a chunked or understated-`Content-Length` body over the limit now gets `413`,
+while one honestly declaring `Content-Length` over 1 MiB passes through
+un-deduplicated (idempotency skipped). If you rely on unbounded buffering,
+restore it explicitly:
+
+```python
+app.add_middleware(IdempotencyMiddleware, store=store, secret=secret, max_body_bytes=None)
+```
+
+`in_flight_ttl` also rose from `30.0` to `60.0`; lower it explicitly if your
+handlers are fast and you want quicker crash-recovery of stuck slots.
+
 ## Configuration caveats
 
 Defaults that aren't safe in every deployment:
@@ -293,11 +323,12 @@ Defaults that aren't safe in every deployment:
   `complete`. (A symmetric `Store.release`-arm gap remains; see
   `docs/DESIGN.md` "Long-handler race closure".) Set
   `in_flight_ttl` above handler p99 to keep the race out of
-  production traffic.
+  production traffic (the default is `60.0`).
 - **`max_body_bytes=None` is a DoS surface.** Unbounded body
   buffering lets an attacker hold a worker by sending a slow multi-GB
-  body. Set an explicit per-deployment limit for production. The
-  default tightens in v0.3.0.
+  body. The default is `1_048_576` (1 MiB); raise it for deployments
+  with legitimately large uploads, but only set `None` if an upstream
+  layer already bounds body size.
 - **`completed_ttl` is both the dedupe window and the replay window.**
   Default 24h. A leaked `Idempotency-Key` is replayable for as long
   as `completed_ttl`; shorter windows lose dedupe coverage, longer

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -39,9 +39,11 @@ This document records the reasoning behind non-obvious choices in `fastapi-idemp
 
 A record has two lifetime phases with separate TTLs:
 
-- `in_flight_ttl` (default 30s): time the handler has to finish. A crashed or
+- `in_flight_ttl` (default 60s): time the handler has to finish. A crashed or
   killed process can't run cleanup, so we rely on the short TTL to reclaim the
-  slot — no separate crash-recovery mechanism in the store.
+  slot — no separate crash-recovery mechanism in the store. The v0.3.0 default
+  rose from 30s to 60s to clear handler p99 + retry backoff, so a slow handler
+  doesn't lose its slot and double-execute on retry.
 - `completed_ttl` (default 24h): time the cached response replays for once the
   handler succeeds. This is the window the client has to safely retry.
 
@@ -161,8 +163,9 @@ new record. The implementation revealed the cost: for Lua to set
    `_serde.py` changes for a marginal benefit.
 
 The benefit at issue: clock drift between workers. On NTP-synced hosts
-the drift is milliseconds; v0.2.0's smallest TTL default is 30 s
-(in-flight), 24 h (completed). A ms-scale skew on a 30 s TTL is 0.03 %.
+the drift is milliseconds; the smallest TTL default is 60 s
+(in-flight), 24 h (completed). A ms-scale skew on a 60 s TTL is under
+0.02 %.
 
 **Trade-off accepted**: Python-clock `created_at`/`expires_at` with
 documented NTP-sync requirement, in exchange for keeping `_serde.py` and

--- a/src/fastapi_idempotency/middleware.py
+++ b/src/fastapi_idempotency/middleware.py
@@ -132,9 +132,11 @@ class IdempotencyMiddleware:
         *,
         secret: bytes | None | _Missing = _SECRET_NOT_SET,
         header_name: str = "Idempotency-Key",
-        in_flight_ttl: float = 30.0,
+        # Production-safe defaults (v0.3.0): 60s clears handler p99 + retry;
+        # 1 MiB fences the body-DoS surface (max_body_bytes=None opts out).
+        in_flight_ttl: float = 60.0,
         completed_ttl: float = 86_400.0,
-        max_body_bytes: int | None = None,
+        max_body_bytes: int | None = 1_048_576,
         require_key: bool = False,
         scope_factory: ScopeFactory | None = None,
     ) -> None:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -71,6 +71,16 @@ def test_missing_secret_kwarg_raises_value_error() -> None:
         IdempotencyMiddleware(echo_app, InMemoryStore())
 
 
+def test_production_safe_defaults() -> None:
+    """v0.3.0 hardening: a bare construction fences the body-DoS surface at
+    1 MiB and gives slow handlers a 60s in-flight slot. Locks the defaults
+    against silent regression — opting out is `max_body_bytes=None`."""
+    middleware = IdempotencyMiddleware(echo_app, InMemoryStore(), secret=None)
+
+    assert middleware.max_body_bytes == 1_048_576
+    assert middleware.in_flight_ttl == 60.0
+
+
 async def test_hmac_secret_caches_response() -> None:
     """End-to-end smoke: a non-None ``secret`` produces working idempotency
     (HMAC fingerprint flows through acquire/complete/replay)."""


### PR DESCRIPTION
Closes #26. Ships production-safe `IdempotencyMiddleware` defaults for v0.3.0.

- `max_body_bytes`: `None` (unbounded) → `1_048_576` (1 MiB) — fences the
  memory-DoS surface of unbounded body buffering.
- `in_flight_ttl`: `30.0` → `60.0` — clears typical handler p99 + retry backoff
  so a slow handler doesn't lose its slot and double-execute.

**Breaking** for anyone relying on unbounded buffering; opt back out with
`max_body_bytes=None`. Change details, defaults reference, and the upgrade note
live in-repo — see rather than restate:

- README § "Configuration" — defaults table + "Upgrading from v0.2.0"
- `docs/DESIGN.md` § lifecycle — `in_flight_ttl` rationale
- CHANGELOG `[Unreleased] → Changed` (BREAKING)

## Review notes

- 2 atomic commits: defaults change + test → docs.
- The new `max_body_bytes` default wires into both fences (Content-Length
  pre-check and in-buffer). Behavior of the limit is already covered by the
  existing explicit-`max_body_bytes=100` tests; the added test locks the
  default *values* against silent regression.
- No existing test relied on the old defaults (all body-limit tests pass an
  explicit limit), so nothing needed adapting.
